### PR TITLE
v1.5.13: Cross-links between Errors and Trends pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.5.12",
+      "version": "1.5.13",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/errors/api/page.js
+++ b/src/app/dashboard/errors/api/page.js
@@ -28,6 +28,8 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import ErrorIcon from '@mui/icons-material/Error';
 import WarningIcon from '@mui/icons-material/Warning';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import Link from 'next/link';
 
 // Time range options for error queries
 const TIME_RANGES = [
@@ -219,6 +221,15 @@ export default function ApiErrorsPage() {
             disabled={errorSummary.loading}
           >
             Refresh
+          </Button>
+          <Button
+            component={Link}
+            href="/dashboard/errors/trends"
+            variant="contained"
+            size="small"
+            startIcon={<TrendingUpIcon />}
+          >
+            Trends
           </Button>
         </Box>
       </Box>

--- a/src/app/dashboard/errors/trends/page.js
+++ b/src/app/dashboard/errors/trends/page.js
@@ -29,6 +29,8 @@ import {
   ResponsiveContainer
 } from 'recharts';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import ErrorIcon from '@mui/icons-material/Error';
+import Link from 'next/link';
 
 // Time range options for error queries
 const TIME_RANGES = [
@@ -175,6 +177,15 @@ export default function ErrorTrendsPage() {
             disabled={errorTimeline.loading}
           >
             Refresh
+          </Button>
+          <Button
+            component={Link}
+            href="/dashboard/errors/api"
+            variant="contained"
+            size="small"
+            startIcon={<ErrorIcon />}
+          >
+            API Errors
           </Button>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- API Errors page: Add "Trends" button
- Error Trends page: Add "API Errors" button

🤖 Generated with [Claude Code](https://claude.ai/code)