### PR TITLE
CALBEAF-101: Rename TangoTiempo → TangoTiempoTest in calops scripts and docs

### DIFF
--- a/VERCEL_DEPLOYMENT_GUIDE.md
+++ b/VERCEL_DEPLOYMENT_GUIDE.md
@@ -72,7 +72,7 @@ Current configuration points to `http://localhost:3010`. You need:
 
 ### Database Access
 - MongoDB cluster appears to be shared between development and production databases
-- `TangoTiempoDevl` database for development
+- `TangoTiempoTest` database for development
 - `TangoTiempoProd` database for production
 - Ensure production database is properly set up
 

--- a/VERCEL_DEPLOYMENT_GUIDE.md
+++ b/VERCEL_DEPLOYMENT_GUIDE.md
@@ -72,7 +72,7 @@ Current configuration points to `http://localhost:3010`. You need:
 
 ### Database Access
 - MongoDB cluster appears to be shared between development and production databases
-- `TangoTiempo` database for development
+- `TangoTiempoDevl` database for development
 - `TangoTiempoProd` database for production
 - Ensure production database is properly set up
 

--- a/scripts/FIREBASE_IMPORT_README.md
+++ b/scripts/FIREBASE_IMPORT_README.md
@@ -147,7 +147,7 @@ If both API and MongoDB fallback approaches fail:
 
 1. Ensure that MongoDB is running (typically on port 27017)
 2. Check that you have the necessary MongoDB connection permissions
-3. Verify that the database name is correct (default: "TangoTiempoDevl")
+3. Verify that the database name is correct (default: "TangoTiempoTest")
 
 ### Input File Problems
 

--- a/scripts/FIREBASE_IMPORT_README.md
+++ b/scripts/FIREBASE_IMPORT_README.md
@@ -147,7 +147,7 @@ If both API and MongoDB fallback approaches fail:
 
 1. Ensure that MongoDB is running (typically on port 27017)
 2. Check that you have the necessary MongoDB connection permissions
-3. Verify that the database name is correct (default: "TangoTiempo")
+3. Verify that the database name is correct (default: "TangoTiempoDevl")
 
 ### Input File Problems
 

--- a/scripts/import-firebase-users.js
+++ b/scripts/import-firebase-users.js
@@ -42,7 +42,7 @@ const API_IMPORT_ENDPOINT = '/api/userlogins/import-firebase';
 
 // MongoDB configuration (fallback only)
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
-const DB_NAME = process.env.DB_NAME || 'TangoTiempoDevl';
+const DB_NAME = process.env.DB_NAME || 'TangoTiempoTest';
 const USER_COLLECTION = 'userLogins';
 const ROLE_COLLECTION = 'roles';
 const APP_ID = process.env.APP_ID || options.appId || '1'; // Default to TangoTiempo

--- a/scripts/import-firebase-users.js
+++ b/scripts/import-firebase-users.js
@@ -42,7 +42,7 @@ const API_IMPORT_ENDPOINT = '/api/userlogins/import-firebase';
 
 // MongoDB configuration (fallback only)
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
-const DB_NAME = process.env.DB_NAME || 'TangoTiempo';
+const DB_NAME = process.env.DB_NAME || 'TangoTiempoDevl';
 const USER_COLLECTION = 'userLogins';
 const ROLE_COLLECTION = 'roles';
 const APP_ID = process.env.APP_ID || options.appId || '1'; // Default to TangoTiempo

--- a/scripts/seed-roles.js
+++ b/scripts/seed-roles.js
@@ -10,7 +10,7 @@
  * 
  * Environment variables:
  * - MONGODB_URI: MongoDB connection string (default: mongodb://localhost:27017)
- * - DB_NAME: Database name (default: TangoTiempo)
+ * - DB_NAME: Database name (default: TangoTiempoDevl)
  * - APP_ID: Application ID (default: 1)
  * 
  * This script reads the roles from be-info/masterdata/roles.json and seeds them into the database.
@@ -41,7 +41,7 @@ for (let i = 0; i < args.length; i++) {
 
 // Configuration
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
-const DB_NAME = process.env.DB_NAME || 'TangoTiempo';
+const DB_NAME = process.env.DB_NAME || 'TangoTiempoDevl';
 const ROLE_COLLECTION = 'roles';
 const APP_ID = process.env.APP_ID || options.appId || '1';
 

--- a/scripts/seed-roles.js
+++ b/scripts/seed-roles.js
@@ -10,7 +10,7 @@
  * 
  * Environment variables:
  * - MONGODB_URI: MongoDB connection string (default: mongodb://localhost:27017)
- * - DB_NAME: Database name (default: TangoTiempoDevl)
+ * - DB_NAME: Database name (default: TangoTiempoTest)
  * - APP_ID: Application ID (default: 1)
  * 
  * This script reads the roles from be-info/masterdata/roles.json and seeds them into the database.
@@ -41,7 +41,7 @@ for (let i = 0; i < args.length; i++) {
 
 // Configuration
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
-const DB_NAME = process.env.DB_NAME || 'TangoTiempoDevl';
+const DB_NAME = process.env.DB_NAME || 'TangoTiempoTest';
 const ROLE_COLLECTION = 'roles';
 const APP_ID = process.env.APP_ID || options.appId || '1';
 


### PR DESCRIPTION
## Summary
- Part of DB rename Phase 2 (epic CALBEAF-97)
- Updates 2 script DB_NAME fallbacks and 2 doc references from `TangoTiempo` → `TangoTiempoTest`
- No Vercel env var change needed — calops calls the API, not MongoDB directly (confirmed by Toby)

## Files changed
- `scripts/import-firebase-users.js` — DB_NAME fallback
- `scripts/seed-roles.js` — DB_NAME fallback + doc comment
- `scripts/FIREBASE_IMPORT_README.md` — troubleshooting default
- `VERCEL_DEPLOYMENT_GUIDE.md` — dev database reference

## Commits
- 6f160f3 — initial TangoTiempoDevl rename
- 69ff118 — rename to final name TangoTiempoTest

Note: branch also contains v1.6.0 Cost Forecast dashboard commits (already shipped) that haven't yet merged to DEVL.

## Test plan
- [x] CalendarBEAF-TEST GREEN on TangoTiempoTest (Quinn confirmed via health check, 2026-04-14)
- [x] API sanity checks pass (categories, organizers, venues)
- [x] No code path change — fallback default only; scripts still accept `DB_NAME` env override

🤖 Generated with [Claude Code](https://claude.com/claude-code)