### PR TITLE
Promote DEVL → TEST: v1.7.0 (CALOPS-49 M0 Health scaffold)

### DIFF
--- a/VERCEL_DEPLOYMENT_GUIDE.md
+++ b/VERCEL_DEPLOYMENT_GUIDE.md
@@ -72,7 +72,7 @@ Current configuration points to `http://localhost:3010`. You need:
 
 ### Database Access
 - MongoDB cluster appears to be shared between development and production databases
-- `TangoTiempo` database for development
+- `TangoTiempoTest` database for development
 - `TangoTiempoProd` database for production
 - Ensure production database is properly set up
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/scripts/FIREBASE_IMPORT_README.md
+++ b/scripts/FIREBASE_IMPORT_README.md
@@ -147,7 +147,7 @@ If both API and MongoDB fallback approaches fail:
 
 1. Ensure that MongoDB is running (typically on port 27017)
 2. Check that you have the necessary MongoDB connection permissions
-3. Verify that the database name is correct (default: "TangoTiempo")
+3. Verify that the database name is correct (default: "TangoTiempoTest")
 
 ### Input File Problems
 

--- a/scripts/import-firebase-users.js
+++ b/scripts/import-firebase-users.js
@@ -42,7 +42,7 @@ const API_IMPORT_ENDPOINT = '/api/userlogins/import-firebase';
 
 // MongoDB configuration (fallback only)
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
-const DB_NAME = process.env.DB_NAME || 'TangoTiempo';
+const DB_NAME = process.env.DB_NAME || 'TangoTiempoTest';
 const USER_COLLECTION = 'userLogins';
 const ROLE_COLLECTION = 'roles';
 const APP_ID = process.env.APP_ID || options.appId || '1'; // Default to TangoTiempo

--- a/scripts/seed-roles.js
+++ b/scripts/seed-roles.js
@@ -10,7 +10,7 @@
  * 
  * Environment variables:
  * - MONGODB_URI: MongoDB connection string (default: mongodb://localhost:27017)
- * - DB_NAME: Database name (default: TangoTiempo)
+ * - DB_NAME: Database name (default: TangoTiempoTest)
  * - APP_ID: Application ID (default: 1)
  * 
  * This script reads the roles from be-info/masterdata/roles.json and seeds them into the database.
@@ -41,7 +41,7 @@ for (let i = 0; i < args.length; i++) {
 
 // Configuration
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017';
-const DB_NAME = process.env.DB_NAME || 'TangoTiempo';
+const DB_NAME = process.env.DB_NAME || 'TangoTiempoTest';
 const ROLE_COLLECTION = 'roles';
 const APP_ID = process.env.APP_ID || options.appId || '1';
 

--- a/src/app/dashboard/costs/page.js
+++ b/src/app/dashboard/costs/page.js
@@ -33,6 +33,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 
 import costsConfig from '@/config/costs-config.json';
+import MongoM0HealthTab from '@/components/costs/MongoM0HealthTab';
 
 function TabPanel({ children, value, index, ...other }) {
   return (
@@ -476,6 +477,7 @@ export default function CostForecastPage() {
         >
           <Tab label="Current Status" />
           <Tab label="Growth Forecast" />
+          <Tab label="M0 Health" />
           <Tab label="Watch List" />
           <Tab label="Configuration" />
         </Tabs>
@@ -488,9 +490,12 @@ export default function CostForecastPage() {
         <GrowthForecastTab scenarios={scenarios} services={services} />
       </TabPanel>
       <TabPanel value={tabValue} index={2}>
-        <WatchListTab watchList={watchList} services={services} />
+        <MongoM0HealthTab config={costsConfig.mongoM0Health} />
       </TabPanel>
       <TabPanel value={tabValue} index={3}>
+        <WatchListTab watchList={watchList} services={services} />
+      </TabPanel>
+      <TabPanel value={tabValue} index={4}>
         <ConfigurationTab lastUpdated={lastUpdated} />
       </TabPanel>
     </Box>

--- a/src/components/costs/MongoM0HealthTab.js
+++ b/src/components/costs/MongoM0HealthTab.js
@@ -1,0 +1,184 @@
+'use client';
+
+import {
+  Box, Typography, Paper, Grid, LinearProgress, Chip, Alert,
+  Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+  Card, CardContent, CircularProgress, Button, Stack
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ErrorIcon from '@mui/icons-material/Error';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+import { useMongoHealth } from '@/lib/mongo-health/useMongoHealth';
+import {
+  calcStorageGauge, calcConnectionsGauge, calcOpsGauge, calcReplicationGauge,
+  calcThrottlingBadge, calcUpgradeRecommendation, LEVELS
+} from '@/lib/mongo-health/calc';
+
+const LEVEL_META = {
+  [LEVELS.CLEAN]: { color: 'success', icon: CheckCircleIcon, label: 'Clean' },
+  [LEVELS.WATCH]: { color: 'warning', icon: WarningAmberIcon, label: 'Watch' },
+  [LEVELS.CRIT]: { color: 'error', icon: ErrorIcon, label: 'Critical' },
+  [LEVELS.UNKNOWN]: { color: 'default', icon: CheckCircleIcon, label: 'Unknown' }
+};
+
+function GaugeCard({ gauge }) {
+  const meta = LEVEL_META[gauge.level];
+  const Icon = meta.icon;
+  const pct = Math.min(gauge.pct ?? 0, 100);
+
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardContent>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+          <Icon color={meta.color} fontSize="small" />
+          <Typography variant="subtitle2">{gauge.label}</Typography>
+        </Stack>
+        <Typography variant="h6" sx={{ mb: 1 }}>{gauge.display}</Typography>
+        <LinearProgress
+          variant="determinate"
+          value={pct}
+          color={meta.color === 'default' ? 'inherit' : meta.color}
+          sx={{ height: 8, borderRadius: 1 }}
+        />
+        <Typography variant="caption" color="text.secondary">
+          {pct.toFixed(0)}% of cap
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ThrottlingBadge({ badge }) {
+  const meta = LEVEL_META[badge.level];
+  const Icon = meta.icon;
+  return (
+    <Card variant="outlined" sx={{ height: '100%', borderColor: `${meta.color}.main`, borderWidth: 2 }}>
+      <CardContent>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+          <Icon color={meta.color} />
+          <Typography variant="subtitle2">Throttling (app-layer proxy)</Typography>
+        </Stack>
+        <Chip label={meta.label} color={meta.color === 'default' ? 'default' : meta.color} size="small" sx={{ mb: 1 }} />
+        <Typography variant="body2" color="text.secondary">p95 latency: {badge.p95}ms</Typography>
+        <Typography variant="body2" color="text.secondary">Slow ops/5min (&gt;200ms): {badge.slow5}</Typography>
+        <Typography variant="caption" display="block" sx={{ mt: 1 }}>{badge.reason}</Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+function UpgradeCard({ rec }) {
+  if (!rec) return null;
+  const severity = rec.urgency === 'now' ? 'error' : 'warning';
+  const title = rec.urgency === 'now' ? 'Upgrade recommended NOW' : 'Plan upgrade soon';
+
+  return (
+    <Alert severity={severity} icon={<TrendingUpIcon />} sx={{ mb: 2 }}>
+      <Typography variant="subtitle2">{title}: {rec.from.tier} → {rec.to.tier}</Typography>
+      <Typography variant="body2">
+        Fired by: <b>{rec.firedBy}</b>. {rec.rationale}
+      </Typography>
+      <Typography variant="body2" sx={{ mt: 0.5 }}>
+        Cost delta: <b>+${rec.costDelta}/mo</b> ({rec.from.tier} ${rec.from.monthlyCost} → {rec.to.tier} ${rec.to.monthlyCost}).
+        In-place resize, no code change.
+      </Typography>
+      <Button
+        variant="outlined"
+        color={severity}
+        size="small"
+        endIcon={<OpenInNewIcon />}
+        href="https://cloud.mongodb.com/"
+        target="_blank"
+        rel="noopener"
+        sx={{ mt: 1 }}
+      >
+        Open Atlas cluster
+      </Button>
+    </Alert>
+  );
+}
+
+function TopCollectionsTable({ rows }) {
+  const sorted = [...(rows || [])].sort((a, b) => b.sizeBytes - a.sizeBytes).slice(0, 10);
+  return (
+    <TableContainer component={Paper} variant="outlined">
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ bgcolor: 'grey.100' }}>
+            <TableCell>Collection</TableCell>
+            <TableCell align="right">Size</TableCell>
+            <TableCell align="right">Docs</TableCell>
+            <TableCell align="right">Indexes</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted.map(c => (
+            <TableRow key={c.name} hover>
+              <TableCell>{c.name}</TableCell>
+              <TableCell align="right">{(c.sizeBytes / 1024 / 1024).toFixed(1)} MB</TableCell>
+              <TableCell align="right">{c.count.toLocaleString()}</TableCell>
+              <TableCell align="right">{c.nindexes}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default function MongoM0HealthTab({ config }) {
+  const { data, loading, error } = useMongoHealth(config);
+
+  if (!config?.enabled) {
+    return <Alert severity="info">M0 Health panel disabled in config.</Alert>;
+  }
+  if (loading && !data) {
+    return <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}><CircularProgress /></Box>;
+  }
+  if (error) {
+    return <Alert severity="error">Failed to load M0 health: {error}</Alert>;
+  }
+  if (!data) return null;
+
+  const storage = calcStorageGauge(data, config.limits);
+  const conns = calcConnectionsGauge(data, config.limits);
+  const ops = calcOpsGauge(data, config.limits);
+  const repl = calcReplicationGauge(data, config.limits);
+  const badge = calcThrottlingBadge(data, config.throttlingProxy);
+  const rec = calcUpgradeRecommendation(
+    [storage, conns, ops, repl], badge, config.tierLadder, config.upgradeTriggers, config.cluster.tier
+  );
+
+  return (
+    <Box>
+      {config.useMockData && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Displaying <b>mock data</b> (CALBEAF-106 endpoint not live yet). Try <code>?mockState=watch</code> or <code>?mockState=throttling</code> to preview alert states.
+        </Alert>
+      )}
+
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        {config.cluster.name} ({config.cluster.tier}, {config.cluster.region})
+      </Typography>
+      <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 2 }}>
+        Captured: {data.capturedAt} · Mongo {config.cluster.mongoVersion}
+      </Typography>
+
+      <UpgradeCard rec={rec} />
+
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} sm={6} md={3}><GaugeCard gauge={storage} /></Grid>
+        <Grid item xs={12} sm={6} md={3}><GaugeCard gauge={conns} /></Grid>
+        <Grid item xs={12} sm={6} md={3}><GaugeCard gauge={ops} /></Grid>
+        <Grid item xs={12} sm={6} md={3}><GaugeCard gauge={repl} /></Grid>
+        <Grid item xs={12} md={6}><ThrottlingBadge badge={badge} /></Grid>
+      </Grid>
+
+      <Typography variant="h6" sx={{ mb: 1 }}>Top collections by size</Typography>
+      <TopCollectionsTable rows={data.perCollection} />
+    </Box>
+  );
+}

--- a/src/config/costs-config.json
+++ b/src/config/costs-config.json
@@ -303,5 +303,49 @@
     { "name": "Twilio", "purpose": "Voice/SMS", "estimatedCost": "Usage-based" },
     { "name": "Stripe", "purpose": "Payments", "estimatedCost": "2.9% + $0.30/txn" }
   ],
-  "lastUpdated": "2026-04-03"
+  "mongoM0Health": {
+    "enabled": true,
+    "useMockData": true,
+    "endpoint": "/api/admin/mongo-health",
+    "refreshIntervalMs": 60000,
+    "cluster": {
+      "name": "TangoTiempoPrimary",
+      "region": "Azure eastus2",
+      "tier": "M0",
+      "mongoVersion": "8.0.20"
+    },
+    "limits": {
+      "storageBytes": 536870912,
+      "storageWarnPct": 70,
+      "storageCritPct": 85,
+      "maxConnections": 500,
+      "connectionsWarnPct": 60,
+      "connectionsCritPct": 80,
+      "sustainedOpsPerSec": 100,
+      "opsWarnPct": 70,
+      "opsCritPct": 85,
+      "replicationLagSecWarn": 30,
+      "replicationLagSecCrit": 60,
+      "slowOpThresholdMs": 200
+    },
+    "throttlingProxy": {
+      "baselineP95Ms": 50,
+      "p95WatchMs": 150,
+      "p95CritMs": 400,
+      "slowOp5minWatch": 5,
+      "slowOp5minCrit": 20
+    },
+    "tierLadder": [
+      { "tier": "M0", "monthlyCost": 0, "storageGb": 0.5, "maxMembers": 200, "note": "POC / current" },
+      { "tier": "M2", "monthlyCost": 9, "storageGb": 2, "maxMembers": 1000, "note": "When M0 ops/sec caps" },
+      { "tier": "M10", "monthlyCost": 60, "storageGb": 10, "maxMembers": 25000, "note": "When M2 connection cap or perf insufficient" },
+      { "tier": "M20", "monthlyCost": 150, "storageGb": 20, "maxMembers": 75000, "note": "When working set > 10GB" },
+      { "tier": "M30", "monthlyCost": 400, "storageGb": 40, "maxMembers": 200000, "note": "When M20 IOPS cap" }
+    ],
+    "upgradeTriggers": [
+      { "from": "M0", "to": "M2", "when": "Disk > 70% sustained, OR opcounters regularly > 80/sec, OR throttling alert fires > 1x/week" },
+      { "from": "M2", "to": "M10", "when": "Connection cap hit, OR data > 1.5GB, OR need Profiler/Performance Advisor" }
+    ]
+  },
+  "lastUpdated": "2026-04-14"
 }

--- a/src/lib/mongo-health/calc.js
+++ b/src/lib/mongo-health/calc.js
@@ -1,0 +1,128 @@
+/**
+ * Pure health calculations for Mongo M0 panel.
+ * No React, no fetch — just config + health data → derived UI state.
+ * Unit-testable; matches thresholds in MasterCalendar/docs/MONGO-M0-BASELINE.md §4–5.
+ */
+
+export const LEVELS = { CLEAN: 'clean', WATCH: 'watch', CRIT: 'crit', UNKNOWN: 'unknown' };
+
+function band(pct, warnPct, critPct) {
+  if (pct == null || Number.isNaN(pct)) return LEVELS.UNKNOWN;
+  if (pct >= critPct) return LEVELS.CRIT;
+  if (pct >= warnPct) return LEVELS.WATCH;
+  return LEVELS.CLEAN;
+}
+
+export function calcStorageGauge(health, limits) {
+  const used = health?.dbStats?.dataSize ?? 0;
+  const cap = limits.storageBytes;
+  const pct = (used / cap) * 100;
+  return {
+    label: 'Disk Usage',
+    value: used,
+    cap,
+    pct,
+    level: band(pct, limits.storageWarnPct, limits.storageCritPct),
+    display: `${(used / 1024 / 1024).toFixed(0)} MB / ${(cap / 1024 / 1024).toFixed(0)} MB`
+  };
+}
+
+export function calcConnectionsGauge(health, limits) {
+  const used = health?.connections?.current ?? 0;
+  const cap = limits.maxConnections;
+  const pct = (used / cap) * 100;
+  return {
+    label: 'Connections',
+    value: used,
+    cap,
+    pct,
+    level: band(pct, limits.connectionsWarnPct, limits.connectionsCritPct),
+    display: `${used} / ${cap}`
+  };
+}
+
+export function calcOpsGauge(health, limits) {
+  const used = health?.opcounters?.totalPerSec ?? 0;
+  const cap = limits.sustainedOpsPerSec;
+  const pct = (used / cap) * 100;
+  return {
+    label: 'Ops/sec',
+    value: used,
+    cap,
+    pct,
+    level: band(pct, limits.opsWarnPct, limits.opsCritPct),
+    display: `${used.toFixed(1)} / ~${cap} ops/sec`
+  };
+}
+
+export function calcReplicationGauge(health, limits) {
+  const lag = health?.replication?.maxSecondaryLagSec ?? 0;
+  let level = LEVELS.CLEAN;
+  if (lag >= limits.replicationLagSecCrit) level = LEVELS.CRIT;
+  else if (lag >= limits.replicationLagSecWarn) level = LEVELS.WATCH;
+  return {
+    label: 'Replication Lag',
+    value: lag,
+    cap: limits.replicationLagSecCrit,
+    pct: (lag / limits.replicationLagSecCrit) * 100,
+    level,
+    display: `${lag}s`
+  };
+}
+
+/**
+ * Throttling proxy — the key signal per Toby (2026-04-14).
+ * Atlas M0 has no API for the "Operation Throttling" graph, so we proxy via
+ * p95 latency + count of ops >200ms. When these rise without traffic rising, M0 is contended.
+ */
+export function calcThrottlingBadge(health, proxy) {
+  const p95 = health?.slowOps?.p95Ms ?? 0;
+  const slow5 = health?.slowOps?.countAbove200_5min ?? 0;
+
+  let level = LEVELS.CLEAN;
+  if (p95 >= proxy.p95CritMs || slow5 >= proxy.slowOp5minCrit) level = LEVELS.CRIT;
+  else if (p95 >= proxy.p95WatchMs || slow5 >= proxy.slowOp5minWatch) level = LEVELS.WATCH;
+
+  return {
+    label: 'Throttling Proxy',
+    level,
+    p95,
+    slow5,
+    reason:
+      level === LEVELS.CRIT
+        ? `p95 ${p95}ms (>= ${proxy.p95CritMs}ms) or ${slow5} slow ops in 5min (>= ${proxy.slowOp5minCrit}) — M0 is throttling`
+        : level === LEVELS.WATCH
+        ? `p95 ${p95}ms rising from baseline ${proxy.baselineP95Ms}ms, or ${slow5} slow ops/5min — contention starting`
+        : `p95 ${p95}ms within baseline, no slow-op spike — clean`
+  };
+}
+
+/**
+ * Upgrade recommendation per MONGO-M0-BASELINE.md §7.
+ * Returns the next tier + delta + specific trigger that fired, or null if clean.
+ */
+export function calcUpgradeRecommendation(gauges, badge, tierLadder, triggers, currentTier = 'M0') {
+  const critical = gauges.some(g => g.level === LEVELS.CRIT) || badge.level === LEVELS.CRIT;
+  const watching = gauges.some(g => g.level === LEVELS.WATCH) || badge.level === LEVELS.WATCH;
+
+  if (!critical && !watching) return null;
+
+  const currentIdx = tierLadder.findIndex(t => t.tier === currentTier);
+  const nextTier = tierLadder[currentIdx + 1];
+  if (!nextTier) return null;
+
+  const current = tierLadder[currentIdx];
+  const delta = nextTier.monthlyCost - current.monthlyCost;
+
+  const firedGauge = gauges.find(g => g.level === LEVELS.CRIT) || gauges.find(g => g.level === LEVELS.WATCH);
+  const trigger = triggers.find(t => t.from === currentTier && t.to === nextTier.tier);
+
+  return {
+    urgency: critical ? 'now' : 'plan',
+    from: current,
+    to: nextTier,
+    costDelta: delta,
+    firedBy: firedGauge?.label || badge.label,
+    rationale: trigger?.when || 'Threshold breached'
+  };
+}

--- a/src/lib/mongo-health/fixtures.js
+++ b/src/lib/mongo-health/fixtures.js
@@ -1,0 +1,99 @@
+/**
+ * Mock fixtures for Mongo M0 Health panel (CALOPS-49).
+ * Shape matches the contract in CALBEAF-106 (Fulton's endpoint spec).
+ * Swap to live fetch by flipping `mongoM0Health.useMockData` → false in costs-config.json.
+ *
+ * Three states exercised: baseline (green), watch (yellow), throttling (red).
+ * Set fixture via `?mockState=baseline|watch|throttling` query param on /dashboard/costs.
+ */
+
+export const BASELINE_FIXTURE = {
+  capturedAt: '2026-04-14T18:00:00Z',
+  dbStats: {
+    dataSize: 78_643_200,
+    storageSize: 94_371_840,
+    indexSize: 12_582_912,
+    objects: 52_481
+  },
+  connections: {
+    current: 47,
+    available: 453,
+    totalCreated: 18_234
+  },
+  opcounters: {
+    windowSec: 60,
+    insertPerSec: 0.1,
+    queryPerSec: 4.2,
+    updatePerSec: 0.3,
+    deletePerSec: 0.05,
+    getmorePerSec: 1.1,
+    commandPerSec: 6.8,
+    totalPerSec: 12.55
+  },
+  replication: {
+    primaryOptime: '2026-04-14T18:00:00Z',
+    maxSecondaryLagSec: 1
+  },
+  perCollection: [
+    { name: 'events', sizeBytes: 32_505_856, count: 18_420, nindexes: 7 },
+    { name: 'organizers', sizeBytes: 14_680_064, count: 1_247, nindexes: 5 },
+    { name: 'venues', sizeBytes: 9_437_184, count: 892, nindexes: 4 },
+    { name: 'userLogins', sizeBytes: 7_340_032, count: 68, nindexes: 3 },
+    { name: 'regions', sizeBytes: 4_194_304, count: 15, nindexes: 2 },
+    { name: 'cities', sizeBytes: 3_670_016, count: 2_341, nindexes: 3 },
+    { name: 'categories', sizeBytes: 2_097_152, count: 47, nindexes: 2 },
+    { name: 'roles', sizeBytes: 524_288, count: 5, nindexes: 2 },
+    { name: 'auditLog', sizeBytes: 3_670_016, count: 8_920, nindexes: 3 },
+    { name: 'applications', sizeBytes: 524_288, count: 3, nindexes: 1 }
+  ],
+  slowOps: {
+    p50Ms: 18,
+    p95Ms: 42,
+    p99Ms: 78,
+    countAbove200_5min: 0,
+    countAbove200_1hr: 1,
+    countAbove200_24hr: 4
+  }
+};
+
+export const WATCH_FIXTURE = {
+  ...BASELINE_FIXTURE,
+  capturedAt: '2026-04-14T18:05:00Z',
+  dbStats: { ...BASELINE_FIXTURE.dbStats, dataSize: 380_000_000, storageSize: 390_000_000 },
+  connections: { ...BASELINE_FIXTURE.connections, current: 340, available: 160 },
+  opcounters: { ...BASELINE_FIXTURE.opcounters, queryPerSec: 35, commandPerSec: 42, totalPerSec: 78 },
+  slowOps: {
+    p50Ms: 28,
+    p95Ms: 180,
+    p99Ms: 310,
+    countAbove200_5min: 7,
+    countAbove200_1hr: 38,
+    countAbove200_24hr: 120
+  }
+};
+
+export const THROTTLING_FIXTURE = {
+  ...BASELINE_FIXTURE,
+  capturedAt: '2026-04-14T18:10:00Z',
+  dbStats: { ...BASELINE_FIXTURE.dbStats, dataSize: 470_000_000, storageSize: 485_000_000 },
+  connections: { ...BASELINE_FIXTURE.connections, current: 460, available: 40 },
+  opcounters: { ...BASELINE_FIXTURE.opcounters, queryPerSec: 60, commandPerSec: 55, totalPerSec: 118 },
+  replication: { ...BASELINE_FIXTURE.replication, maxSecondaryLagSec: 85 },
+  slowOps: {
+    p50Ms: 85,
+    p95Ms: 620,
+    p99Ms: 1_240,
+    countAbove200_5min: 34,
+    countAbove200_1hr: 290,
+    countAbove200_24hr: 1_850
+  }
+};
+
+export function getFixtureFor(state) {
+  switch (state) {
+    case 'watch': return WATCH_FIXTURE;
+    case 'throttling': return THROTTLING_FIXTURE;
+    case 'baseline':
+    default: return BASELINE_FIXTURE;
+  }
+}

--- a/src/lib/mongo-health/useMongoHealth.js
+++ b/src/lib/mongo-health/useMongoHealth.js
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { getFixtureFor } from './fixtures';
+
+/**
+ * useMongoHealth — fetches M0 health from CALBEAF-106 endpoint, or returns a mock fixture
+ * when `config.useMockData` is true. Same return shape in both modes.
+ */
+export function useMongoHealth(config) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchHealth = useCallback(async () => {
+    if (!config?.enabled) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+
+    if (config.useMockData) {
+      const state =
+        typeof window !== 'undefined'
+          ? new URLSearchParams(window.location.search).get('mockState')
+          : null;
+      setData(getFixtureFor(state || 'baseline'));
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const res = await fetch(config.endpoint, { credentials: 'include' });
+      if (!res.ok) throw new Error(`health endpoint ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e.message || 'fetch failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [config?.enabled, config?.useMockData, config?.endpoint]);
+
+  useEffect(() => {
+    fetchHealth();
+    const ms = config?.refreshIntervalMs;
+    if (!ms || config?.useMockData) return;
+    const id = setInterval(fetchHealth, ms);
+    return () => clearInterval(id);
+  }, [fetchHealth, config?.refreshIntervalMs, config?.useMockData]);
+
+  return { data, loading, error, refetch: fetchHealth };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
     "deploymentEnabled": {
       "DEVL": true,
       "TEST": true,
-      "PROD": false
+      "PROD": false,
+      "_PROD_comment": "PROD auto-deploy disabled for safety. Use 'vercel --prod' to deploy manually after PR merge."
     }
   }
 }


### PR DESCRIPTION
## Summary
Promote DEVL → TEST for v1.7.0.

**Includes:**
- CALOPS-49: M0 Health panel scaffold on Cost Forecast tab (mock-driven, 3 states via ?mockState=)
- CALBEAF-101: TangoTiempo → TangoTiempoTest DB rename (already live in both repos)

## Test plan (on cal-ops-test)
- [ ] Navigate to /dashboard/costs → M0 Health tab renders
- [ ] Gauges show baseline green data (realistic calendar values)
- [ ] Add `?mockState=watch` → yellow gauges + "plan upgrade" card
- [ ] Add `?mockState=throttling` → red gauges + "upgrade NOW" card
- [ ] Other Cost Forecast tabs (Current Status / Growth / Watch List / Configuration) unchanged
- [ ] No console errors