### PR TITLE
CALOPS-50: What-If parametric cost calculator tab

### DIFF
--- a/src/app/dashboard/costs/page.js
+++ b/src/app/dashboard/costs/page.js
@@ -34,6 +34,7 @@ import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 
 import costsConfig from '@/config/costs-config.json';
 import MongoM0HealthTab from '@/components/costs/MongoM0HealthTab';
+import WhatIfTab from '@/components/costs/WhatIfTab';
 
 function TabPanel({ children, value, index, ...other }) {
   return (
@@ -478,6 +479,7 @@ export default function CostForecastPage() {
           <Tab label="Current Status" />
           <Tab label="Growth Forecast" />
           <Tab label="M0 Health" />
+          <Tab label="What-If" />
           <Tab label="Watch List" />
           <Tab label="Configuration" />
         </Tabs>
@@ -493,9 +495,12 @@ export default function CostForecastPage() {
         <MongoM0HealthTab config={costsConfig.mongoM0Health} />
       </TabPanel>
       <TabPanel value={tabValue} index={3}>
-        <WatchListTab watchList={watchList} services={services} />
+        <WhatIfTab config={costsConfig.whatIfModel} />
       </TabPanel>
       <TabPanel value={tabValue} index={4}>
+        <WatchListTab watchList={watchList} services={services} />
+      </TabPanel>
+      <TabPanel value={tabValue} index={5}>
         <ConfigurationTab lastUpdated={lastUpdated} />
       </TabPanel>
     </Box>

--- a/src/components/costs/WhatIfTab.js
+++ b/src/components/costs/WhatIfTab.js
@@ -1,0 +1,159 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Box, Typography, Paper, Grid, TextField, Button, Alert, Chip, Stack,
+  Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+  Card, CardContent, Divider, Tooltip
+} from '@mui/material';
+import CalculateIcon from '@mui/icons-material/Calculate';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
+import {
+  computeMonthlyCost, INPUT_DEFAULTS, INPUT_SCHEMA, PRESETS
+} from '@/lib/cost-model/formula';
+
+function fmtMoney(n) {
+  if (n < 0.01) return '$0.00';
+  if (n < 10) return `$${n.toFixed(2)}`;
+  return `$${Math.round(n).toLocaleString()}`;
+}
+
+function InputField({ spec, value, onChange }) {
+  return (
+    <TextField
+      label={spec.label}
+      type="number"
+      size="small"
+      value={value}
+      onChange={e => onChange(Number(e.target.value))}
+      fullWidth
+      inputProps={{ min: spec.min, max: spec.max, step: spec.step }}
+      helperText={spec.unit}
+    />
+  );
+}
+
+export default function WhatIfTab({ config }) {
+  const [inputs, setInputs] = useState(INPUT_DEFAULTS);
+
+  const result = useMemo(() => {
+    if (!config?.enabled) return null;
+    return computeMonthlyCost(inputs, config.units);
+  }, [inputs, config]);
+
+  if (!config?.enabled) {
+    return <Alert severity="info">What-if model disabled in config.</Alert>;
+  }
+
+  const applyPreset = (preset) => {
+    setInputs(prev => ({ ...prev, ...preset }));
+  };
+
+  const perMemberCost = result && inputs.M > 0 ? result.total / inputs.M : 0;
+
+  return (
+    <Box>
+      <Alert severity="info" sx={{ mb: 2 }} icon={<CalculateIcon />}>
+        Parametric cost projection using the formula in <b>{config.sourceDoc}</b> §5.
+        Change any input to see live cost. Useful for stress-testing scale scenarios before committing to a tier upgrade.
+      </Alert>
+
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>Quick presets</Typography>
+      <Stack direction="row" spacing={1} sx={{ mb: 3, flexWrap: 'wrap', gap: 1 }}>
+        {PRESETS.map(p => (
+          <Chip
+            key={p.id}
+            label={p.label}
+            variant="outlined"
+            clickable
+            onClick={() => applyPreset(p)}
+          />
+        ))}
+        <Chip
+          label="Reset to defaults"
+          variant="outlined"
+          clickable
+          color="default"
+          icon={<RestartAltIcon />}
+          onClick={() => setInputs(INPUT_DEFAULTS)}
+        />
+      </Stack>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>Inputs</Typography>
+            <Grid container spacing={2}>
+              {INPUT_SCHEMA.map(spec => (
+                <Grid item xs={12} sm={6} key={spec.key}>
+                  <InputField
+                    spec={spec}
+                    value={inputs[spec.key]}
+                    onChange={v => setInputs(prev => ({ ...prev, [spec.key]: v }))}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          </Paper>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="subtitle2" color="text.secondary">Projected monthly cost</Typography>
+              <Typography variant="h3" sx={{ my: 1 }}>{result ? fmtMoney(result.total) : '—'}</Typography>
+              <Stack direction="row" spacing={2}>
+                <Typography variant="body2" color="text.secondary">
+                  Active: <b>{result?.derived.activeUsers.toLocaleString(undefined, {maximumFractionDigits: 0})}</b>
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Concurrent: <b>{result?.derived.avgConcurrent.toLocaleString(undefined, {maximumFractionDigits: 0})}</b>
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Per member: <b>${perMemberCost.toFixed(4)}/mo</b>
+                </Typography>
+              </Stack>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="caption" color="text.secondary" display="block">
+                Auto-selected Mongo tier: <b>{result?.mongoTier.tier}</b> (${result?.mongoTier.monthlyCost}/mo, up to {result?.mongoTier.maxMembers.toLocaleString()} members)
+              </Typography>
+            </CardContent>
+          </Card>
+
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Line-item breakdown
+            <Tooltip title="Formula from METRICS_COST_MODEL.md §5. Unit costs pinned 2026-Q2; update in costs-config.json when vendor pricing changes.">
+              <InfoOutlinedIcon fontSize="small" sx={{ ml: 1, verticalAlign: 'middle', color: 'text.secondary' }} />
+            </Tooltip>
+          </Typography>
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow sx={{ bgcolor: 'grey.100' }}>
+                  <TableCell>Line</TableCell>
+                  <TableCell>Detail</TableCell>
+                  <TableCell align="right">Monthly</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {result?.lines.map(l => (
+                  <TableRow key={l.id} hover>
+                    <TableCell>{l.label}</TableCell>
+                    <TableCell><Typography variant="caption" color="text.secondary">{l.detail}</Typography></TableCell>
+                    <TableCell align="right">{fmtMoney(l.cost)}</TableCell>
+                  </TableRow>
+                ))}
+                <TableRow sx={{ bgcolor: 'grey.50' }}>
+                  <TableCell colSpan={2}><b>Total</b></TableCell>
+                  <TableCell align="right"><b>{result ? fmtMoney(result.total) : '—'}</b></TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/config/costs-config.json
+++ b/src/config/costs-config.json
@@ -347,5 +347,28 @@
       { "from": "M2", "to": "M10", "when": "Connection cap hit, OR data > 1.5GB, OR need Profiler/Performance Advisor" }
     ]
   },
+  "whatIfModel": {
+    "enabled": true,
+    "units": {
+      "signalrConnMinute": 0.0000015,
+      "signalrMessage": 0.000001,
+      "signalrFreeMsgsPerMonth": 30000000,
+      "fnInvocation": 0.0000002,
+      "fnGbSecond": 0.000016,
+      "fnFreeExecPerMo": 1000000,
+      "blobGbMonth": 0.018,
+      "bandwidthGb": 0.087,
+      "mongoTierLadder": [
+        { "tier": "M0", "monthlyCost": 0, "storageGb": 0.5, "maxMembers": 200 },
+        { "tier": "M2", "monthlyCost": 9, "storageGb": 2, "maxMembers": 1000 },
+        { "tier": "M10", "monthlyCost": 60, "storageGb": 10, "maxMembers": 25000 },
+        { "tier": "M20", "monthlyCost": 150, "storageGb": 20, "maxMembers": 75000 },
+        { "tier": "M30", "monthlyCost": 400, "storageGb": 40, "maxMembers": 200000 },
+        { "tier": "M30+", "monthlyCost": 1000, "storageGb": 80, "maxMembers": 1000000 }
+      ]
+    },
+    "unitsLastReviewed": "2026-Q2",
+    "sourceDoc": "MessageHub/docs/METRICS_COST_MODEL.md"
+  },
   "lastUpdated": "2026-04-14"
 }

--- a/src/lib/cost-model/formula.js
+++ b/src/lib/cost-model/formula.js
@@ -1,0 +1,124 @@
+/**
+ * Parametric cost model — MessageHub/docs/METRICS_COST_MODEL.md §5 formula.
+ *
+ * Given input parameters (§3) and unit costs (§4), returns a line-item cost breakdown.
+ * Pure function — unit-testable, no side effects.
+ *
+ * Input contract:
+ *   inputs: { M, mau, conc, idle, idleSavings, mpm, rMsg, rpm,
+ *             convN, convC, convH, niches, imgPct, imgKb }
+ *   units:  { signalrConnMinute, signalrMessage, signalrFreeMsgsPerMonth,
+ *             fnInvocation, fnGbSecond, fnFreeExecPerMo,
+ *             mongoTierLadder: [{tier, monthlyCost, storageGb, maxMembers}],
+ *             blobGbMonth, bandwidthGb }
+ */
+
+const MIN_PER_MONTH = 43_200;
+
+function pickMongoTier(memberCount, ladder) {
+  for (const t of ladder) {
+    if (memberCount <= t.maxMembers) return t;
+  }
+  return ladder[ladder.length - 1];
+}
+
+export function computeMonthlyCost(inputs, units) {
+  const {
+    M, mau, conc, idleSavings,
+    mpm, rMsg, rpm,
+    convN, convC, convH,
+    imgPct, imgKb
+  } = inputs;
+
+  const activeUsers = M * mau;
+  const avgConcurrent = activeUsers * conc;
+
+  const connectedMinutes = activeUsers * conc * MIN_PER_MONTH * (1 - idleSavings);
+  const signalrConnCost = connectedMinutes * units.signalrConnMinute;
+
+  const messagesSent = activeUsers * mpm;
+  const messageDeliveries = messagesSent * rMsg;
+  const billableDeliveries = Math.max(0, messageDeliveries - units.signalrFreeMsgsPerMonth);
+  const signalrMsgCost = billableDeliveries * units.signalrMessage;
+
+  const functionReads = messagesSent * rpm;
+  const functionWrites = messagesSent;
+  const billableFnCalls = Math.max(0, functionReads + functionWrites - units.fnFreeExecPerMo);
+  const functionCost = billableFnCalls * units.fnInvocation;
+
+  const storageBytesPerMonth =
+    messagesSent * 12 * 1024 +
+    activeUsers * mpm * imgPct * imgKb * 1024;
+  const storageGb = storageBytesPerMonth / (1024 * 1024 * 1024);
+  const storageCost = storageGb * units.blobGbMonth;
+
+  const mongoTier = pickMongoTier(M, units.mongoTierLadder);
+  const mongoTierCost = mongoTier.monthlyCost;
+
+  const convConnMinutes = convN * convC * convH * 60;
+  const convCostAnnual = convConnMinutes * units.signalrConnMinute;
+  const convCostMonthly = convCostAnnual / 12;
+
+  const total =
+    signalrConnCost +
+    signalrMsgCost +
+    functionCost +
+    storageCost +
+    mongoTierCost +
+    convCostMonthly;
+
+  return {
+    derived: { activeUsers, avgConcurrent, messagesSent, messageDeliveries, storageGb },
+    lines: [
+      { id: 'signalr_conn', label: 'SignalR connection-minutes', cost: signalrConnCost,
+        detail: `${connectedMinutes.toLocaleString(undefined, {maximumFractionDigits: 0})} conn-min` },
+      { id: 'signalr_msg', label: 'SignalR messages (above free tier)', cost: signalrMsgCost,
+        detail: messageDeliveries > units.signalrFreeMsgsPerMonth
+          ? `${billableDeliveries.toLocaleString(undefined, {maximumFractionDigits: 0})} billable`
+          : `${messageDeliveries.toLocaleString(undefined, {maximumFractionDigits: 0})} in free tier` },
+      { id: 'functions', label: 'Azure Functions', cost: functionCost,
+        detail: billableFnCalls > 0
+          ? `${billableFnCalls.toLocaleString(undefined, {maximumFractionDigits: 0})} billable invocations`
+          : 'in free tier' },
+      { id: 'storage', label: 'Blob storage + messages', cost: storageCost,
+        detail: `${storageGb.toFixed(2)} GB` },
+      { id: 'mongo', label: `MongoDB Atlas (${mongoTier.tier})`, cost: mongoTierCost,
+        detail: `${mongoTier.storageGb}GB tier, up to ${mongoTier.maxMembers.toLocaleString()} members` },
+      { id: 'conv', label: 'Convention spikes (amortized)', cost: convCostMonthly,
+        detail: `${convN}× ${convC.toLocaleString()} concurrent × ${convH}h/yr` }
+    ],
+    total,
+    mongoTier
+  };
+}
+
+export const INPUT_DEFAULTS = {
+  M: 20000, mau: 0.5, conc: 0.05, idle: 15, idleSavings: 0.4,
+  mpm: 30, rMsg: 15, rpm: 50,
+  convN: 2, convC: 4000, convH: 48,
+  niches: 1, imgPct: 0.05, imgKb: 200
+};
+
+export const PRESETS = [
+  { id: 'poc',    label: 'POC (100 members)',             M: 100,   mau: 0.5, conc: 0.03, mpm: 30 },
+  { id: 'small',  label: 'Small niche (500)',             M: 500,   mau: 0.5, conc: 0.05, mpm: 30 },
+  { id: 'medium', label: 'Medium niche (5K)',             M: 5000,  mau: 0.5, conc: 0.05, mpm: 30 },
+  { id: 'bhs',    label: 'BHS full scale (20K)',          M: 20000, mau: 0.5, conc: 0.05, mpm: 30 },
+  { id: 'multi',  label: 'Multi-niche (75K across 3)',    M: 75000, mau: 0.5, conc: 0.05, mpm: 30 },
+  { id: 'big',    label: '500K / 10 niches',              M: 500000, mau: 0.5, conc: 0.05, mpm: 30 }
+];
+
+export const INPUT_SCHEMA = [
+  { key: 'M',           label: 'Total members',             unit: 'count',  min: 1,    max: 10_000_000, step: 100 },
+  { key: 'mau',         label: 'Monthly active fraction',   unit: 'ratio',  min: 0,    max: 1,          step: 0.01 },
+  { key: 'conc',        label: 'Avg concurrent / MAU',      unit: 'ratio',  min: 0,    max: 1,          step: 0.01 },
+  { key: 'idleSavings', label: 'Idle-disconnect savings',   unit: 'ratio',  min: 0,    max: 1,          step: 0.05 },
+  { key: 'mpm',         label: 'Messages / MAU / month',    unit: 'count',  min: 0,    max: 1000,       step: 1 },
+  { key: 'rMsg',        label: 'Recipients / message',      unit: 'count',  min: 1,    max: 10_000,     step: 1 },
+  { key: 'rpm',         label: 'Reads / message sent',      unit: 'count',  min: 0,    max: 1000,       step: 1 },
+  { key: 'convN',       label: 'Convention events / year',  unit: 'count',  min: 0,    max: 52,         step: 1 },
+  { key: 'convC',       label: 'Convention peak concurrent',unit: 'count',  min: 0,    max: 100_000,    step: 100 },
+  { key: 'convH',       label: 'Convention duration',       unit: 'hours',  min: 0,    max: 168,        step: 1 },
+  { key: 'imgPct',      label: 'Messages w/ attachment',    unit: 'ratio',  min: 0,    max: 1,          step: 0.01 },
+  { key: 'imgKb',       label: 'Avg attachment size',       unit: 'KB',     min: 0,    max: 10_000,     step: 10 }
+];


### PR DESCRIPTION
New What-If tab on Cost Forecast page. Parametric calculator using METRICS_COST_MODEL.md §5 formula. Pure client-side, no backend deps. 6 preset scenarios, auto-selects Mongo tier, config-driven unit costs. Build + lint green.