### PR TITLE
Promote DEVL → TEST: v1.9.0 (CALOPS-49 live data)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/components/costs/MongoM0HealthTab.js
+++ b/src/components/costs/MongoM0HealthTab.js
@@ -10,42 +10,56 @@ import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import ErrorIcon from '@mui/icons-material/Error';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 import { useMongoHealth } from '@/lib/mongo-health/useMongoHealth';
 import {
+  parseNotes,
   calcStorageGauge, calcConnectionsGauge, calcOpsGauge, calcReplicationGauge,
   calcThrottlingBadge, calcUpgradeRecommendation, LEVELS
 } from '@/lib/mongo-health/calc';
 
 const LEVEL_META = {
-  [LEVELS.CLEAN]: { color: 'success', icon: CheckCircleIcon, label: 'Clean' },
-  [LEVELS.WATCH]: { color: 'warning', icon: WarningAmberIcon, label: 'Watch' },
-  [LEVELS.CRIT]: { color: 'error', icon: ErrorIcon, label: 'Critical' },
-  [LEVELS.UNKNOWN]: { color: 'default', icon: CheckCircleIcon, label: 'Unknown' }
+  [LEVELS.CLEAN]:       { color: 'success', icon: CheckCircleIcon, label: 'Clean' },
+  [LEVELS.WATCH]:       { color: 'warning', icon: WarningAmberIcon, label: 'Watch' },
+  [LEVELS.CRIT]:        { color: 'error',   icon: ErrorIcon, label: 'Critical' },
+  [LEVELS.UNAVAILABLE]: { color: 'inherit', icon: RemoveCircleOutlineIcon, label: 'Unavailable' },
+  [LEVELS.UNKNOWN]:     { color: 'inherit', icon: CheckCircleIcon, label: 'Unknown' }
 };
 
 function GaugeCard({ gauge }) {
   const meta = LEVEL_META[gauge.level];
   const Icon = meta.icon;
+  const unavailable = gauge.level === LEVELS.UNAVAILABLE;
   const pct = Math.min(gauge.pct ?? 0, 100);
 
   return (
-    <Card variant="outlined" sx={{ height: '100%' }}>
+    <Card variant="outlined" sx={{ height: '100%', opacity: unavailable ? 0.6 : 1 }}>
       <CardContent>
         <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
-          <Icon color={meta.color} fontSize="small" />
+          <Icon color={meta.color === 'inherit' ? 'disabled' : meta.color} fontSize="small" />
           <Typography variant="subtitle2">{gauge.label}</Typography>
         </Stack>
         <Typography variant="h6" sx={{ mb: 1 }}>{gauge.display}</Typography>
-        <LinearProgress
-          variant="determinate"
-          value={pct}
-          color={meta.color === 'default' ? 'inherit' : meta.color}
-          sx={{ height: 8, borderRadius: 1 }}
-        />
-        <Typography variant="caption" color="text.secondary">
-          {pct.toFixed(0)}% of cap
-        </Typography>
+        {!unavailable && (
+          <>
+            <LinearProgress
+              variant="determinate"
+              value={pct}
+              color={meta.color === 'inherit' ? 'inherit' : meta.color}
+              sx={{ height: 8, borderRadius: 1 }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              {pct.toFixed(0)}% of cap
+            </Typography>
+          </>
+        )}
+        {unavailable && (
+          <Typography variant="caption" color="text.secondary">
+            See notes below
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );
@@ -54,16 +68,23 @@ function GaugeCard({ gauge }) {
 function ThrottlingBadge({ badge }) {
   const meta = LEVEL_META[badge.level];
   const Icon = meta.icon;
+  const unavailable = badge.level === LEVELS.UNAVAILABLE;
+  const borderColor = meta.color === 'inherit' ? 'grey.300' : `${meta.color}.main`;
+
   return (
-    <Card variant="outlined" sx={{ height: '100%', borderColor: `${meta.color}.main`, borderWidth: 2 }}>
+    <Card variant="outlined" sx={{ height: '100%', borderColor, borderWidth: 2, opacity: unavailable ? 0.7 : 1 }}>
       <CardContent>
         <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
-          <Icon color={meta.color} />
+          <Icon color={meta.color === 'inherit' ? 'disabled' : meta.color} />
           <Typography variant="subtitle2">Throttling (app-layer proxy)</Typography>
         </Stack>
-        <Chip label={meta.label} color={meta.color === 'default' ? 'default' : meta.color} size="small" sx={{ mb: 1 }} />
-        <Typography variant="body2" color="text.secondary">p95 latency: {badge.p95}ms</Typography>
-        <Typography variant="body2" color="text.secondary">Slow ops/5min (&gt;200ms): {badge.slow5}</Typography>
+        <Chip label={meta.label} color={meta.color === 'inherit' ? 'default' : meta.color} size="small" sx={{ mb: 1 }} />
+        {!unavailable && (
+          <>
+            <Typography variant="body2" color="text.secondary">p95 latency: {badge.p95}ms</Typography>
+            <Typography variant="body2" color="text.secondary">Slow ops/5min (&gt;200ms): {badge.slow5}</Typography>
+          </>
+        )}
         <Typography variant="caption" display="block" sx={{ mt: 1 }}>{badge.reason}</Typography>
       </CardContent>
     </Card>
@@ -129,6 +150,26 @@ function TopCollectionsTable({ rows }) {
   );
 }
 
+function NotesFooter({ notes }) {
+  if (!Array.isArray(notes) || notes.length === 0) return null;
+  return (
+    <Box sx={{ mt: 3, p: 2, bgcolor: 'grey.50', borderRadius: 1, border: 1, borderColor: 'grey.200' }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <InfoOutlinedIcon fontSize="small" color="info" />
+        <Typography variant="subtitle2">Endpoint notes</Typography>
+      </Stack>
+      {notes.map((n, i) => {
+        const text = typeof n === 'string' ? n : `${n.block}: ${n.status}${n.reason ? ` (${n.reason})` : ''}`;
+        return (
+          <Typography key={i} variant="caption" display="block" color="text.secondary">
+            • {text}
+          </Typography>
+        );
+      })}
+    </Box>
+  );
+}
+
 export default function MongoM0HealthTab({ config }) {
   const { data, loading, error } = useMongoHealth(config);
 
@@ -143,11 +184,12 @@ export default function MongoM0HealthTab({ config }) {
   }
   if (!data) return null;
 
+  const blockStatus = parseNotes(data.notes);
   const storage = calcStorageGauge(data, config.limits);
-  const conns = calcConnectionsGauge(data, config.limits);
-  const ops = calcOpsGauge(data, config.limits);
-  const repl = calcReplicationGauge(data, config.limits);
-  const badge = calcThrottlingBadge(data, config.throttlingProxy);
+  const conns = calcConnectionsGauge(data, config.limits, blockStatus);
+  const ops = calcOpsGauge(data, config.limits, blockStatus);
+  const repl = calcReplicationGauge(data, config.limits, blockStatus);
+  const badge = calcThrottlingBadge(data, config.throttlingProxy, blockStatus);
   const rec = calcUpgradeRecommendation(
     [storage, conns, ops, repl], badge, config.tierLadder, config.upgradeTriggers, config.cluster.tier
   );
@@ -156,7 +198,7 @@ export default function MongoM0HealthTab({ config }) {
     <Box>
       {config.useMockData && (
         <Alert severity="info" sx={{ mb: 2 }}>
-          Displaying <b>mock data</b> (CALBEAF-106 endpoint not live yet). Try <code>?mockState=watch</code> or <code>?mockState=throttling</code> to preview alert states.
+          Displaying <b>mock data</b> (CALBEAF-106 endpoint not live yet). Try <code>?mockState=watch</code> or <code>?mockState=throttling</code> to preview alert states on M2+ tier.
         </Alert>
       )}
 
@@ -179,6 +221,8 @@ export default function MongoM0HealthTab({ config }) {
 
       <Typography variant="h6" sx={{ mb: 1 }}>Top collections by size</Typography>
       <TopCollectionsTable rows={data.perCollection} />
+
+      <NotesFooter notes={data.notes} />
     </Box>
   );
 }

--- a/src/config/costs-config.json
+++ b/src/config/costs-config.json
@@ -305,7 +305,7 @@
   ],
   "mongoM0Health": {
     "enabled": true,
-    "useMockData": true,
+    "useMockData": false,
     "endpoint": "/api/ops/mongo-health",
     "refreshIntervalMs": 60000,
     "cluster": {

--- a/src/config/costs-config.json
+++ b/src/config/costs-config.json
@@ -306,7 +306,7 @@
   "mongoM0Health": {
     "enabled": true,
     "useMockData": true,
-    "endpoint": "/api/admin/mongo-health",
+    "endpoint": "/api/ops/mongo-health",
     "refreshIntervalMs": 60000,
     "cluster": {
       "name": "TangoTiempoPrimary",

--- a/src/lib/mongo-health/calc.js
+++ b/src/lib/mongo-health/calc.js
@@ -2,9 +2,20 @@
  * Pure health calculations for Mongo M0 panel.
  * No React, no fetch — just config + health data → derived UI state.
  * Unit-testable; matches thresholds in MasterCalendar/docs/MONGO-M0-BASELINE.md §4–5.
+ *
+ * Handles M0 free-tier reality: several response blocks (connections,
+ * opcounters, replication, slowOps) may come back stubbed/zero because the
+ * TangoTiempoBE Mongo user lacks serverStatus / replSetGetStatus privilege
+ * on M0. Unavailable gauges render gray ("— M0 limit") instead of false-green.
  */
 
-export const LEVELS = { CLEAN: 'clean', WATCH: 'watch', CRIT: 'crit', UNKNOWN: 'unknown' };
+export const LEVELS = {
+  CLEAN: 'clean',
+  WATCH: 'watch',
+  CRIT: 'crit',
+  UNAVAILABLE: 'unavailable',
+  UNKNOWN: 'unknown'
+};
 
 function band(pct, warnPct, critPct) {
   if (pct == null || Number.isNaN(pct)) return LEVELS.UNKNOWN;
@@ -13,57 +24,87 @@ function band(pct, warnPct, critPct) {
   return LEVELS.CLEAN;
 }
 
+/**
+ * Parse notes[] (array of strings OR structured objects) into a
+ * block-availability map. Accepts both shapes so Fulton can upgrade
+ * the endpoint from string → structured without breaking the UI.
+ */
+export function parseNotes(notes) {
+  const status = {
+    connections: 'ok',
+    opcounters: 'ok',
+    replication: 'ok',
+    slowOps: 'ok'
+  };
+  if (!Array.isArray(notes)) return status;
+
+  for (const n of notes) {
+    if (typeof n === 'string') {
+      const s = n.toLowerCase();
+      if (s.includes('serverstatus') || s.includes('connections')) status.connections = 'unavailable';
+      if (s.includes('serverstatus') || s.includes('opcounters')) status.opcounters = 'unavailable';
+      if (s.includes('replication') || s.includes('replsetgetstatus')) status.replication = 'unavailable';
+      if (s.includes('slowops') || s.includes('app insights') || s.includes('appinsights')) status.slowOps = 'stubbed';
+    } else if (n && typeof n === 'object' && n.block) {
+      if (status[n.block] !== undefined) status[n.block] = n.status || 'unavailable';
+    }
+  }
+  return status;
+}
+
+function unavailableGauge(label) {
+  return { label, value: null, cap: null, pct: null, level: LEVELS.UNAVAILABLE, display: '— (M0 limit)' };
+}
+
 export function calcStorageGauge(health, limits) {
   const used = health?.dbStats?.dataSize ?? 0;
   const cap = limits.storageBytes;
   const pct = (used / cap) * 100;
   return {
     label: 'Disk Usage',
-    value: used,
-    cap,
-    pct,
+    value: used, cap, pct,
     level: band(pct, limits.storageWarnPct, limits.storageCritPct),
     display: `${(used / 1024 / 1024).toFixed(0)} MB / ${(cap / 1024 / 1024).toFixed(0)} MB`
   };
 }
 
-export function calcConnectionsGauge(health, limits) {
+export function calcConnectionsGauge(health, limits, blockStatus) {
+  if (blockStatus?.connections !== 'ok') return unavailableGauge('Connections');
   const used = health?.connections?.current ?? 0;
   const cap = limits.maxConnections;
   const pct = (used / cap) * 100;
   return {
     label: 'Connections',
-    value: used,
-    cap,
-    pct,
+    value: used, cap, pct,
     level: band(pct, limits.connectionsWarnPct, limits.connectionsCritPct),
     display: `${used} / ${cap}`
   };
 }
 
-export function calcOpsGauge(health, limits) {
+export function calcOpsGauge(health, limits, blockStatus) {
+  if (blockStatus?.opcounters !== 'ok') return unavailableGauge('Ops/sec');
   const used = health?.opcounters?.totalPerSec ?? 0;
   const cap = limits.sustainedOpsPerSec;
   const pct = (used / cap) * 100;
   return {
     label: 'Ops/sec',
-    value: used,
-    cap,
-    pct,
+    value: used, cap, pct,
     level: band(pct, limits.opsWarnPct, limits.opsCritPct),
     display: `${used.toFixed(1)} / ~${cap} ops/sec`
   };
 }
 
-export function calcReplicationGauge(health, limits) {
-  const lag = health?.replication?.maxSecondaryLagSec ?? 0;
+export function calcReplicationGauge(health, limits, blockStatus) {
+  if (blockStatus?.replication !== 'ok') return unavailableGauge('Replication Lag');
+  const lag = health?.replication?.maxSecondaryLagSec;
+  if (lag == null) return unavailableGauge('Replication Lag');
+
   let level = LEVELS.CLEAN;
   if (lag >= limits.replicationLagSecCrit) level = LEVELS.CRIT;
   else if (lag >= limits.replicationLagSecWarn) level = LEVELS.WATCH;
   return {
     label: 'Replication Lag',
-    value: lag,
-    cap: limits.replicationLagSecCrit,
+    value: lag, cap: limits.replicationLagSecCrit,
     pct: (lag / limits.replicationLagSecCrit) * 100,
     level,
     display: `${lag}s`
@@ -71,11 +112,21 @@ export function calcReplicationGauge(health, limits) {
 }
 
 /**
- * Throttling proxy — the key signal per Toby (2026-04-14).
- * Atlas M0 has no API for the "Operation Throttling" graph, so we proxy via
- * p95 latency + count of ops >200ms. When these rise without traffic rising, M0 is contended.
+ * Throttling proxy — key signal per Toby (2026-04-14).
+ * On M0, slowOps may be stubbed pending App Insights wiring. When stubbed,
+ * render the badge as UNAVAILABLE (gray) rather than falsely green.
  */
-export function calcThrottlingBadge(health, proxy) {
+export function calcThrottlingBadge(health, proxy, blockStatus) {
+  if (blockStatus?.slowOps && blockStatus.slowOps !== 'ok') {
+    return {
+      label: 'Throttling Proxy',
+      level: LEVELS.UNAVAILABLE,
+      p95: null,
+      slow5: null,
+      reason: 'Slow-op metrics unavailable — App Insights integration pending'
+    };
+  }
+
   const p95 = health?.slowOps?.p95Ms ?? 0;
   const slow5 = health?.slowOps?.countAbove200_5min ?? 0;
 
@@ -99,11 +150,18 @@ export function calcThrottlingBadge(health, proxy) {
 
 /**
  * Upgrade recommendation per MONGO-M0-BASELINE.md §7.
- * Returns the next tier + delta + specific trigger that fired, or null if clean.
+ * Unavailable gauges do not trigger upgrade recs (they carry no signal).
  */
 export function calcUpgradeRecommendation(gauges, badge, tierLadder, triggers, currentTier = 'M0') {
-  const critical = gauges.some(g => g.level === LEVELS.CRIT) || badge.level === LEVELS.CRIT;
-  const watching = gauges.some(g => g.level === LEVELS.WATCH) || badge.level === LEVELS.WATCH;
+  const signalGauges = gauges.filter(g => g.level !== LEVELS.UNAVAILABLE && g.level !== LEVELS.UNKNOWN);
+  const badgeCounts = badge.level !== LEVELS.UNAVAILABLE && badge.level !== LEVELS.UNKNOWN;
+
+  const critical =
+    signalGauges.some(g => g.level === LEVELS.CRIT) ||
+    (badgeCounts && badge.level === LEVELS.CRIT);
+  const watching =
+    signalGauges.some(g => g.level === LEVELS.WATCH) ||
+    (badgeCounts && badge.level === LEVELS.WATCH);
 
   if (!critical && !watching) return null;
 
@@ -114,7 +172,9 @@ export function calcUpgradeRecommendation(gauges, badge, tierLadder, triggers, c
   const current = tierLadder[currentIdx];
   const delta = nextTier.monthlyCost - current.monthlyCost;
 
-  const firedGauge = gauges.find(g => g.level === LEVELS.CRIT) || gauges.find(g => g.level === LEVELS.WATCH);
+  const firedGauge =
+    signalGauges.find(g => g.level === LEVELS.CRIT) ||
+    signalGauges.find(g => g.level === LEVELS.WATCH);
   const trigger = triggers.find(t => t.from === currentTier && t.to === nextTier.tier);
 
   return {

--- a/src/lib/mongo-health/fixtures.js
+++ b/src/lib/mongo-health/fixtures.js
@@ -1,39 +1,41 @@
 /**
  * Mock fixtures for Mongo M0 Health panel (CALOPS-49).
- * Shape matches the contract in CALBEAF-106 (Fulton's endpoint spec).
- * Swap to live fetch by flipping `mongoM0Health.useMockData` → false in costs-config.json.
+ * Shape matches the CALBEAF-106 endpoint contract as shipped 2026-04-14.
  *
- * Three states exercised: baseline (green), watch (yellow), throttling (red).
- * Set fixture via `?mockState=baseline|watch|throttling` query param on /dashboard/costs.
+ * M0 free tier limitation: the `TangoTiempoBE` Mongo user cannot call
+ * serverStatus or replSetGetStatus. So `connections`, `opcounters`, and
+ * `replication` come back stubbed at zero / null on real M0, with a note
+ * in notes[] explaining why. `slowOps` is also stubbed pending
+ * Application Insights integration.
+ *
+ * Three mock states via ?mockState=baseline|watch|throttling.
+ * baseline reflects real M0 reality (partial data). watch/throttling
+ * simulate M2+ where serverStatus is available — useful for previewing
+ * how the panel looks when the data is fully populated.
  */
 
+const M0_NOTES = [
+  'connections: unavailable on M0 free tier — TangoTiempoBE user lacks serverStatus privilege',
+  'opcounters: unavailable on M0 free tier — TangoTiempoBE user lacks serverStatus privilege',
+  'replication: unavailable on M0 free tier — TangoTiempoBE user lacks replSetGetStatus privilege',
+  'slowOps: stubbed at zero — Application Insights integration pending'
+];
+
 export const BASELINE_FIXTURE = {
-  capturedAt: '2026-04-14T18:00:00Z',
+  capturedAt: '2026-04-14T20:00:00Z',
   dbStats: {
     dataSize: 78_643_200,
     storageSize: 94_371_840,
     indexSize: 12_582_912,
     objects: 52_481
   },
-  connections: {
-    current: 47,
-    available: 453,
-    totalCreated: 18_234
-  },
+  connections: { current: 0, available: 0, totalCreated: 0 },
   opcounters: {
     windowSec: 60,
-    insertPerSec: 0.1,
-    queryPerSec: 4.2,
-    updatePerSec: 0.3,
-    deletePerSec: 0.05,
-    getmorePerSec: 1.1,
-    commandPerSec: 6.8,
-    totalPerSec: 12.55
+    insertPerSec: 0, queryPerSec: 0, updatePerSec: 0, deletePerSec: 0,
+    getmorePerSec: 0, commandPerSec: 0, totalPerSec: 0
   },
-  replication: {
-    primaryOptime: '2026-04-14T18:00:00Z',
-    maxSecondaryLagSec: 1
-  },
+  replication: { primaryOptime: null, maxSecondaryLagSec: null },
   perCollection: [
     { name: 'events', sizeBytes: 32_505_856, count: 18_420, nindexes: 7 },
     { name: 'organizers', sizeBytes: 14_680_064, count: 1_247, nindexes: 5 },
@@ -42,51 +44,55 @@ export const BASELINE_FIXTURE = {
     { name: 'regions', sizeBytes: 4_194_304, count: 15, nindexes: 2 },
     { name: 'cities', sizeBytes: 3_670_016, count: 2_341, nindexes: 3 },
     { name: 'categories', sizeBytes: 2_097_152, count: 47, nindexes: 2 },
-    { name: 'roles', sizeBytes: 524_288, count: 5, nindexes: 2 },
     { name: 'auditLog', sizeBytes: 3_670_016, count: 8_920, nindexes: 3 },
+    { name: 'roles', sizeBytes: 524_288, count: 5, nindexes: 2 },
     { name: 'applications', sizeBytes: 524_288, count: 3, nindexes: 1 }
   ],
   slowOps: {
-    p50Ms: 18,
-    p95Ms: 42,
-    p99Ms: 78,
-    countAbove200_5min: 0,
-    countAbove200_1hr: 1,
-    countAbove200_24hr: 4
-  }
+    p50Ms: 0, p95Ms: 0, p99Ms: 0,
+    countAbove200_5min: 0, countAbove200_1hr: 0, countAbove200_24hr: 0
+  },
+  notes: M0_NOTES
 };
+
+const RICH_CONNECTIONS = { current: 340, available: 160, totalCreated: 18_234 };
+const RICH_OPCOUNTERS = {
+  windowSec: 60,
+  insertPerSec: 0.1, queryPerSec: 35, updatePerSec: 0.3, deletePerSec: 0.05,
+  getmorePerSec: 1.1, commandPerSec: 42, totalPerSec: 78.55
+};
+const RICH_REPL_OK = { primaryOptime: '2026-04-14T20:00:00Z', maxSecondaryLagSec: 1 };
 
 export const WATCH_FIXTURE = {
   ...BASELINE_FIXTURE,
-  capturedAt: '2026-04-14T18:05:00Z',
+  capturedAt: '2026-04-14T20:05:00Z',
   dbStats: { ...BASELINE_FIXTURE.dbStats, dataSize: 380_000_000, storageSize: 390_000_000 },
-  connections: { ...BASELINE_FIXTURE.connections, current: 340, available: 160 },
-  opcounters: { ...BASELINE_FIXTURE.opcounters, queryPerSec: 35, commandPerSec: 42, totalPerSec: 78 },
+  connections: RICH_CONNECTIONS,
+  opcounters: RICH_OPCOUNTERS,
+  replication: RICH_REPL_OK,
   slowOps: {
-    p50Ms: 28,
-    p95Ms: 180,
-    p99Ms: 310,
-    countAbove200_5min: 7,
-    countAbove200_1hr: 38,
-    countAbove200_24hr: 120
-  }
+    p50Ms: 28, p95Ms: 180, p99Ms: 310,
+    countAbove200_5min: 7, countAbove200_1hr: 38, countAbove200_24hr: 120
+  },
+  notes: ['Preview: M2+ tier with full serverStatus access — all gauges live']
 };
 
 export const THROTTLING_FIXTURE = {
   ...BASELINE_FIXTURE,
-  capturedAt: '2026-04-14T18:10:00Z',
+  capturedAt: '2026-04-14T20:10:00Z',
   dbStats: { ...BASELINE_FIXTURE.dbStats, dataSize: 470_000_000, storageSize: 485_000_000 },
-  connections: { ...BASELINE_FIXTURE.connections, current: 460, available: 40 },
-  opcounters: { ...BASELINE_FIXTURE.opcounters, queryPerSec: 60, commandPerSec: 55, totalPerSec: 118 },
-  replication: { ...BASELINE_FIXTURE.replication, maxSecondaryLagSec: 85 },
+  connections: { current: 460, available: 40, totalCreated: 52_100 },
+  opcounters: {
+    windowSec: 60,
+    insertPerSec: 0.5, queryPerSec: 60, updatePerSec: 1, deletePerSec: 0.1,
+    getmorePerSec: 2, commandPerSec: 55, totalPerSec: 118.6
+  },
+  replication: { primaryOptime: '2026-04-14T20:08:35Z', maxSecondaryLagSec: 85 },
   slowOps: {
-    p50Ms: 85,
-    p95Ms: 620,
-    p99Ms: 1_240,
-    countAbove200_5min: 34,
-    countAbove200_1hr: 290,
-    countAbove200_24hr: 1_850
-  }
+    p50Ms: 85, p95Ms: 620, p99Ms: 1_240,
+    countAbove200_5min: 34, countAbove200_1hr: 290, countAbove200_24hr: 1_850
+  },
+  notes: ['Preview: M2+ tier simulating throttling — upgrade-now recommendation should fire']
 };
 
 export function getFixtureFor(state) {

--- a/src/lib/mongo-health/useMongoHealth.js
+++ b/src/lib/mongo-health/useMongoHealth.js
@@ -1,13 +1,19 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
 import { getFixtureFor } from './fixtures';
 
 /**
- * useMongoHealth — fetches M0 health from CALBEAF-106 endpoint, or returns a mock fixture
- * when `config.useMockData` is true. Same return shape in both modes.
+ * useMongoHealth — fetches M0 health from CALBEAF-106 endpoint via calops
+ * `/api/ops/[...path]` proxy (which forwards with the Azure Functions key
+ * server-side and passes through the firebase bearer token).
+ *
+ * Returns a mock fixture when `config.useMockData` is true. Same return
+ * shape in both modes.
  */
 export function useMongoHealth(config) {
+  const { getAuthToken } = useAuth();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -31,7 +37,11 @@ export function useMongoHealth(config) {
     }
 
     try {
-      const res = await fetch(config.endpoint, { credentials: 'include' });
+      const token = getAuthToken ? await getAuthToken() : null;
+      const headers = { 'Accept': 'application/json' };
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+
+      const res = await fetch(config.endpoint, { headers, credentials: 'include' });
       if (!res.ok) throw new Error(`health endpoint ${res.status}`);
       setData(await res.json());
     } catch (e) {
@@ -39,7 +49,7 @@ export function useMongoHealth(config) {
     } finally {
       setLoading(false);
     }
-  }, [config?.enabled, config?.useMockData, config?.endpoint]);
+  }, [config?.enabled, config?.useMockData, config?.endpoint, getAuthToken]);
 
   useEffect(() => {
     fetchHealth();


### PR DESCRIPTION
## Summary
Flip CALOPS-49 to live data. M0 Health panel now pulls from CALBEAF-106 v1.25.3.

## Test plan (on cal-ops-test, after login)
- [ ] Navigate to /dashboard/costs → M0 Health tab
- [ ] Disk Usage gauge shows real data (~16.7 MB / 512 MB)
- [ ] Connections / Ops/sec / Replication Lag gauges render gray "— (M0 limit)"
- [ ] Throttling badge shows "Unavailable" with App Insights pending note
- [ ] Top collections table shows real events/organizers/venues with real doc counts
- [ ] Endpoint notes footer lists 4 items (3× atlas-m0-no-admin, 1× appinsights-not-wired)
- [ ] No upgrade recommendation fires (correct — dbStats is well under 70%)