### PR TITLE
CALOPS-53: v1.10.1 → TEST: vercel.json schema fix (unblock TEST builds)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,1 @@
-{
-  "git": {
-    "deploymentEnabled": {
-      "DEVL": true,
-      "TEST": true,
-      "PROD": false,
-      "_PROD_comment": "PROD auto-deploy disabled for safety. Use 'vercel --prod' to deploy manually after PR merge."
-    }
-  }
-}
+{}


### PR DESCRIPTION
## Summary

**Critical**: TEST has been silently broken for 17 days. Last successful calops-test deploy was 29 days ago (pre-v1.7.0). v1.7.0/1.8.0/1.9.0/1.10.0 we thought were live on TEST are NOT — Vercel was rejecting the schema and skipping every build.

**Root cause**: `vercel.json` had per-branch `git.deploymentEnabled` object. Vercel now requires a boolean. Validation fails → `buildSkipped: true`.

**Fix**: empty out `vercel.json` (no `git` block). calops-test resumes auto-deploying on TEST branch pushes via project defaults (productionBranch=TEST, framework=nextjs).

## PROD safety

Preserved by deferral. calops-prod stays safely blocked because the still-broken PROD branch's `vercel.json` continues to fail schema. When the PROD-side fix later lands (with DEPLOY-PROD), I'll set `commandForIgnoringBuildStep` on calops-prod via Vercel API with a smart-script form (`[ "$VERCEL_GIT_PROVIDER" = "github" ] && exit 0 || exit 1`) to allow manual `vercel --prod` while blocking git auto-deploys.

## Version

`1.10.0` → `1.10.1` (patch — config fix, no functional change).

## Unblocks

- CALOPS-52 Activity Map view validation on TEST
- All future TEST deploys

## Test plan

- [ ] Vercel `calops-test` build succeeds (status=READY, not ERROR)
- [ ] `https://calops-test.vercel.app/dashboard/analytics/activity-map` returns 200 with auth, not 404
- [ ] Existing routes (`/dashboard/analytics/activity-tracking` etc.) still load
- [ ] Mapbox token in calops-test env is picked up — tiles render

🤖 Generated with [Claude Code](https://claude.com/claude-code)