### PR TITLE
CALOPS-52 fix: v1.10.2 → TEST: empty map area (flex-height collapse)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -56,6 +56,8 @@ export default function ActivityMapView({ records }) {
         zoomOffset={mapboxToken ? -1 : 0}
       />
 
+      <InvalidateOnMount />
+
       {records.map((rec) => {
         const userLat = rec.userLocation?.latitude;
         const userLng = rec.userLocation?.longitude;
@@ -135,5 +137,19 @@ function RecenterIfEmpty({ hasRecords }) {
       map.setView(USA_CENTER, USA_ZOOM);
     }
   }, [hasRecords, map]);
+  return null;
+}
+
+// Force the map to recompute size after mount — fixes the case where a flex parent
+// hasn't finished its layout pass when MapContainer first measures itself, leaving
+// the map at 0×0 with no tiles loaded. Run on mount + once after a short delay.
+function InvalidateOnMount() {
+  const map = useMap();
+  useEffect(() => {
+    const tick = () => map.invalidateSize();
+    tick();
+    const t = setTimeout(tick, 250);
+    return () => clearTimeout(t);
+  }, [map]);
   return null;
 }

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -92,8 +92,8 @@ export default function ActivityMapPage() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 100px)' }}>
-        <Box sx={{ p: 2, pb: 1 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 100px)', minHeight: 600 }}>
+        <Box sx={{ p: 2, pb: 1, flexShrink: 0 }}>
           <Typography variant="h5" gutterBottom>
             Activity Map
           </Typography>
@@ -189,8 +189,18 @@ export default function ActivityMapPage() {
           )}
         </Box>
 
-        {/* Map area */}
-        <Box sx={{ flexGrow: 1, position: 'relative', mx: 2, mb: 2, border: '1px solid', borderColor: 'divider' }}>
+        {/* Map area — rocking-chair layout: relative parent + absolute-fill child guarantees the
+            MapContainer always has a concrete sized box to mount into, regardless of flex timing. */}
+        <Box sx={{
+          flexGrow: 1,
+          position: 'relative',
+          mx: 2,
+          mb: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          minHeight: 500,
+          overflow: 'hidden',
+        }}>
           {loading && (
             <Box sx={{
               position: 'absolute', top: 8, right: 8, zIndex: 1000,
@@ -201,7 +211,9 @@ export default function ActivityMapPage() {
               <Typography variant="caption">Loading…</Typography>
             </Box>
           )}
-          <ActivityMapView records={records} />
+          <Box sx={{ position: 'absolute', inset: 0 }}>
+            <ActivityMapView records={records} />
+          </Box>
         </Box>
       </Box>
     </LocalizationProvider>


### PR DESCRIPTION
## Summary

Bug fix for the activity-map view that just landed on TEST. Page header rendered fine but the map area below was blank — Leaflet's classic flex-height collapse problem.

## Fix

- **Layout**: rocking-chair wrapper (relative parent + absolute-fill child) ensures the MapContainer always mounts into a sized box
- **`minHeight: 500`** as a floor so the map region never collapses below 500px
- **`InvalidateOnMount`**: calls `map.invalidateSize()` on mount + 250ms — handles any leftover size-resolution races
- **`flexShrink: 0`** on the header Box so the header doesn't squash when minHeight kicks in

## Version

`1.10.1` → `1.10.2` (patch — bug fix)

## Test plan

- [ ] Vercel calops-test build succeeds
- [ ] Map tiles render (Mapbox style if token present)
- [ ] Zoom controls appear in upper-left
- [ ] USA-centered view at zoom 4 by default
- [ ] Existing 0-records state still shows the correct "0 of 0 records" copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)