### PR TITLE
CALOPS-52 fix: v1.10.3 → TEST: DatePicker crash + Geo-source 'All' selectable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -23,7 +23,7 @@ import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import WifiIcon from '@mui/icons-material/Wifi';
 import axios from 'axios';
-import { format, subDays } from 'date-fns';
+import { format, subDays, isValid } from 'date-fns';
 import { useAppContext } from '@/lib/AppContext';
 
 // SSR-disabled map (Leaflet refuses to render on the server)
@@ -51,6 +51,10 @@ export default function ActivityMapPage() {
   const [error, setError] = useState(null);
 
   const fetchRecords = useCallback(async () => {
+    if (!isValid(startDate) || !isValid(endDate)) {
+      setError('Pick valid Start and Finish dates.');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -115,20 +119,22 @@ export default function ActivityMapPage() {
               <DatePicker
                 label="Start"
                 value={startDate}
-                onChange={(d) => d && setStartDate(d)}
+                onChange={(d) => isValid(d) && setStartDate(d)}
                 slotProps={{ textField: { size: 'small' } }}
               />
               <DatePicker
                 label="Finish"
                 value={endDate}
-                onChange={(d) => d && setEndDate(d)}
+                onChange={(d) => isValid(d) && setEndDate(d)}
                 slotProps={{ textField: { size: 'small' } }}
               />
               <FormControl size="small" sx={{ minWidth: 180 }}>
-                <InputLabel>Geo source</InputLabel>
+                <InputLabel shrink>Geo source</InputLabel>
                 <Select
                   value={geoSource}
                   label="Geo source"
+                  displayEmpty
+                  notched
                   onChange={(e) => setGeoSource(e.target.value)}
                 >
                   <MenuItem value="">All</MenuItem>
@@ -172,7 +178,7 @@ export default function ActivityMapPage() {
 
             <Box sx={{ mt: 1.5 }}>
               <Typography variant="caption" color="text.secondary">
-                Range: <strong>{format(startDate, 'MMM d, yyyy')}</strong> → <strong>{format(endDate, 'MMM d, yyyy')}</strong>
+                Range: <strong>{isValid(startDate) ? format(startDate, 'MMM d, yyyy') : '—'}</strong> → <strong>{isValid(endDate) ? format(endDate, 'MMM d, yyyy') : '—'}</strong>
                 {' • '}
                 Showing <strong>{renderableCount}</strong> of <strong>{total.toLocaleString()}</strong> records
                 {records.length < total && ` (capped at ${DEFAULT_LIMIT} for this view)`}


### PR DESCRIPTION
## Two bugs

1. DatePicker mid-edit crashes page (RangeError: Invalid time value) — fixed by isValid() guards on every consumer.
2. Geo-source dropdown 'All' (value='') unselectable — added MUI's required displayEmpty/notched/shrink pattern.

## Version
1.10.2 → 1.10.3 (patch)

## Test
- [ ] Edit Start date with keyboard → no crash
- [ ] Geo source: pick GoogleBrowser, then pick All → All sticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)