### PR TITLE
CALOPS-54: v1.10.4 → TEST: User Activity org-types crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/analytics/user-activity/page.js
+++ b/src/app/dashboard/analytics/user-activity/page.js
@@ -697,9 +697,20 @@ export default function UserActivityPage() {
                                   <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                                     <Typography variant="caption" color="text.secondary">Types</Typography>
                                     <Box sx={{ display: 'flex', gap: 0.5 }}>
-                                      {org.organizerTypes?.map((type, i) => (
-                                        <Chip key={i} label={type} size="small" color="secondary" sx={{ fontSize: '0.65rem', height: 18 }} />
-                                      )) || '-'}
+                                      {(() => {
+                                        const t = org.organizerTypes;
+                                        const labels = [];
+                                        if (t?.isVenue) labels.push('Venue');
+                                        if (t?.isTeacher) labels.push('Teacher');
+                                        if (t?.isMaestro) labels.push('Maestro');
+                                        if (t?.isDJ) labels.push('DJ');
+                                        if (t?.isOrchestra) labels.push('Orchestra');
+                                        return labels.length
+                                          ? labels.map((type, i) => (
+                                              <Chip key={i} label={type} size="small" color="secondary" sx={{ fontSize: '0.65rem', height: 18 }} />
+                                            ))
+                                          : '-';
+                                      })()}
                                     </Box>
                                   </Box>
                                   <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>


### PR DESCRIPTION
## Summary
- Fix production crash on `/dashboard/analytics/user-activity` when search results include an Organizer record
- `org.organizerTypes` is a boolean object (`{isVenue, isTeacher, isMaestro, isDJ, isOrchestra}`), not an array
- Code at line 700 was calling `.map()` on it; optional chaining didn't short-circuit (object is truthy), throwing `TypeError: i.map is not a function`
- Derive label list from boolean keys — same pattern used elsewhere in the codebase

## Root cause
Inconsistent treatment of `organizerTypes` shape on a recently-added page (no JIRA prefix in the original commit). All other UI surfaces (`organizers/page.js`, `OrganizerMobileCards.js`, `data-health/page.js`, `user-logins/page.js`) already access it correctly as an object.

## Test plan
- [ ] After merge, verify on test.calops.tangotiempo.com:
  - Open `/dashboard/analytics/user-activity`
  - Search by IP / Firebase User ID / Visitor ID that returns at least one matched user with a linked organizer
  - Expand the **User Details** accordion → confirm Organizer card renders with Type chips (no console error)
- [ ] Console clean — no `i.map is not a function` error

## Version
1.10.3 → 1.10.4 (patch — bug fix)

## JIRA
CALOPS-54