### PR TITLE
CALOPS-55: API Errors report — add UA / device-class / IP / customDimensions columns

### DIFF
--- a/src/app/api/appinsights/route.js
+++ b/src/app/api/appinsights/route.js
@@ -92,7 +92,7 @@ const QUERIES = {
     requests
     | where timestamp > ago(${timeRange})
     | where resultCode startswith "4" or resultCode startswith "5"
-    | project timestamp, name, resultCode, duration, url, client_City, client_CountryOrRegion, operation_Id
+    | project timestamp, name, resultCode, duration, url, client_City, client_CountryOrRegion, client_Browser, client_Type, client_IP, customDimensions, operation_Id
     | order by timestamp desc
     | take 100
   `,

--- a/src/app/dashboard/errors/api/page.js
+++ b/src/app/dashboard/errors/api/page.js
@@ -361,13 +361,17 @@ export default function ApiErrorsPage() {
                         <TableCell>Status</TableCell>
                         <TableCell>Duration</TableCell>
                         <TableCell>Location</TableCell>
+                        <TableCell>Browser</TableCell>
+                        <TableCell>Type</TableCell>
+                        <TableCell>IP</TableCell>
+                        <TableCell>CustomDims</TableCell>
                         <TableCell>Operation ID</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
                       {recentErrors.rows.length === 0 ? (
                         <TableRow>
-                          <TableCell colSpan={6} align="center">
+                          <TableCell colSpan={10} align="center">
                             No recent errors
                           </TableCell>
                         </TableRow>
@@ -392,6 +396,41 @@ export default function ApiErrorsPage() {
                               {row.client_City && row.client_CountryOrRegion
                                 ? `${row.client_City}, ${row.client_CountryOrRegion}`
                                 : row.client_CountryOrRegion || '-'}
+                            </TableCell>
+                            <TableCell sx={{ fontSize: '0.75rem', maxWidth: 140 }}>
+                              <Tooltip title={row.client_Browser || ''}>
+                                <span style={{ display: 'inline-block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 140 }}>
+                                  {row.client_Browser || '-'}
+                                </span>
+                              </Tooltip>
+                            </TableCell>
+                            <TableCell sx={{ fontSize: '0.75rem' }}>
+                              {row.client_Type || '-'}
+                            </TableCell>
+                            <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                              <Tooltip title="Copy IP">
+                                <span
+                                  style={{ cursor: row.client_IP ? 'pointer' : 'default' }}
+                                  onClick={() => row.client_IP && navigator.clipboard.writeText(row.client_IP)}
+                                >
+                                  {row.client_IP || '-'}
+                                </span>
+                              </Tooltip>
+                            </TableCell>
+                            <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem', maxWidth: 200 }}>
+                              {(() => {
+                                const cd = row.customDimensions;
+                                if (!cd) return '-';
+                                const s = typeof cd === 'string' ? cd : JSON.stringify(cd);
+                                const truncated = s.length > 120 ? s.substring(0, 120) + '…' : s;
+                                return (
+                                  <Tooltip title={s}>
+                                    <span style={{ display: 'inline-block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200 }}>
+                                      {truncated}
+                                    </span>
+                                  </Tooltip>
+                                );
+                              })()}
                             </TableCell>
                             <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
                               <Tooltip title="Copy Operation ID">


### PR DESCRIPTION
## Summary
Extends the API Errors report with 4 new columns surfacing fields already queryable in App Insights but not previously projected:
- `client_Browser` (e.g., "Safari 26.4")
- `client_Type` (mobile / PC)
- `client_IP` (with copy-on-click)
- `customDimensions` (raw-truncated to 120 chars + tooltip-full)

## Context
TT /calendar LOC anonymous-mobile P1 incident 2026-05-12. Boston iPhone user signature was reconstructable only via direct Azure Portal queries because these fields weren't in the CalOps surface. Future incidents of this class will be one-glance triageable in the dashboard.

Quinn beat-11 ratified scope: customDimensions confirmed by Fulton (19:05Z stitch raw) as standard Azure Functions Host.Results telemetry — raw-truncated v1 is sufficient, no parsed-key v2 refinement needed.

Auth-state column NOT included — calendar-be-af does not stamp `user_AuthenticatedId` (Fulton finding). That column requires a separate Sprint-6 BE-stamp ticket.

## Files changed
- `src/app/api/appinsights/route.js` — KQL projection extended in `recentErrors` query
- `src/app/dashboard/errors/api/page.js` — 4 new columns with tooltip-overflow + copy-on-click IP

Diff: +41 / −2

## Test plan
- [x] eslint clean
- [ ] Deploy to DEVL → manual smoke: open API Errors page, confirm 4 new columns render with real data
- [ ] Promote to TEST → repeat smoke
- [ ] Window 1 PROD-promote PR (held pending Fulton BE PROD landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)