### PR TITLE
v1.11.0: bump for Window 1 PROD-promote bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",


### PR DESCRIPTION
## Summary
Version bump 1.10.5 → 1.11.0 on TEST in preparation for the Window 1 CalOps PROD-promote (Step 5).

## Bundle scope (consolidated into PROD-promote PR)
- CALOPS-49 M0 Health panel live data (paired w/ CALBEAF-106)
- CALOPS-50 What-If parametric cost calculator
- CALOPS-52 Activity Map + 4 follow-up fixes
- CALOPS-53 vercel.json schema fix
- CALOPS-54 User Activity org.organizerTypes crash fix
- CALOPS-55 API Errors columns (UA / device / IP / customDimensions)
- Watch List action polish

## Versioning
Minor bump per Quinn beat-17 Option A — multi-feature bundle warrants minor over patch. PROD goes from 1.6.0 → 1.11.0 in this Window 1 PROD-promote.

## Authorization trail
- Toby Window-1 greenlight (via Gotan) 2026-05-12
- Quinn CRK ratification beat-26 (4 gates satisfied)
- Toby vercel-curl smoke authorization (via Number2 relay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)