### PR TITLE
CALOPS-56: Activity Map filters — Source / QTY / IP / Viewport / Locals-only

### DIFF
--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { Fragment, useEffect } from 'react';
-import { MapContainer, TileLayer, CircleMarker, Circle, Polyline, Popup, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, CircleMarker, Circle, Polyline, Popup, useMap, useMapEvents } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 
 const USA_CENTER = [39.5, -98.5];
@@ -28,7 +28,7 @@ function FixLeafletIcons() {
   return null;
 }
 
-export default function ActivityMapView({ records }) {
+export default function ActivityMapView({ records, onBoundsChange }) {
   const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
   const tileUrl = mapboxToken
     ? `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxToken}`
@@ -52,6 +52,7 @@ export default function ActivityMapView({ records }) {
       />
 
       <InvalidateOnMount />
+      <BoundsReporter onBoundsChange={onBoundsChange} />
 
       {records.map((rec) => {
         const userLat = rec.userLocation?.latitude;
@@ -141,5 +142,26 @@ function InvalidateOnMount() {
     const t = setTimeout(tick, 250);
     return () => clearTimeout(t);
   }, [map]);
+  return null;
+}
+
+// Reports current viewport bounds to parent on mount + after pan/zoom.
+// Plain object so the parent doesn't have to handle Leaflet types.
+function BoundsReporter({ onBoundsChange }) {
+  const emit = (map) => {
+    if (!onBoundsChange) return;
+    const b = map.getBounds();
+    onBoundsChange({
+      north: b.getNorth(),
+      south: b.getSouth(),
+      east: b.getEast(),
+      west: b.getWest(),
+    });
+  };
+  const map = useMapEvents({
+    moveend: () => emit(map),
+    zoomend: () => emit(map),
+  });
+  useEffect(() => { emit(map); /* report initial bounds once */ }, [map]); // eslint-disable-line react-hooks/exhaustive-deps
   return null;
 }

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import {
   Box,
@@ -15,6 +15,15 @@ import {
   Select,
   MenuItem,
   Stack,
+  Slider,
+  Switch,
+  FormControlLabel,
+  TextField,
+  Autocomplete,
+  Divider,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
 } from '@mui/material';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
@@ -22,11 +31,12 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import WifiIcon from '@mui/icons-material/Wifi';
+import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
+import HomeIcon from '@mui/icons-material/Home';
 import axios from 'axios';
 import { format, subDays, isValid } from 'date-fns';
 import { useAppContext } from '@/lib/AppContext';
 
-// SSR-disabled map (Leaflet refuses to render on the server)
 const ActivityMapView = dynamic(() => import('./ActivityMapView'), {
   ssr: false,
   loading: () => (
@@ -36,7 +46,29 @@ const ActivityMapView = dynamic(() => import('./ActivityMapView'), {
   ),
 });
 
-const DEFAULT_LIMIT = 200; // BE caps at 200 per call
+const DEFAULT_LIMIT = 200;
+
+const SOURCE_OPTIONS = [
+  { key: 'GoogleBrowser',     label: 'Browser GPS', color: '#2e7d32' },
+  { key: 'GoogleGeolocation', label: 'Google IP',   color: '#1976d2' },
+  { key: 'IPInfoIO',          label: 'IP lookup',   color: '#757575' },
+];
+const ALL_SOURCE_KEYS = SOURCE_OPTIONS.map((s) => s.key);
+
+function haversineKm(a, b) {
+  if (a?.latitude == null || a?.longitude == null) return null;
+  if (b?.latitude == null || b?.longitude == null) return null;
+  const R = 6371;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
 
 export default function ActivityMapPage() {
   const { currentApp } = useAppContext();
@@ -44,11 +76,19 @@ export default function ActivityMapPage() {
 
   const [startDate, setStartDate] = useState(subDays(new Date(), 7));
   const [endDate, setEndDate] = useState(new Date());
-  const [geoSource, setGeoSource] = useState('');
   const [records, setRecords] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  // Client-side filter state (no re-fetch on change)
+  const [geoSources, setGeoSources] = useState(ALL_SOURCE_KEYS);
+  const [minQty, setMinQty] = useState(1);
+  const [ipFilter, setIpFilter] = useState('');
+  const [viewportFilter, setViewportFilter] = useState(false);
+  const [viewportBounds, setViewportBounds] = useState(null);
+  const [localsOnly, setLocalsOnly] = useState(false);
+  const [localsKm, setLocalsKm] = useState(50);
 
   const fetchRecords = useCallback(async () => {
     if (!isValid(startDate) || !isValid(endDate)) {
@@ -64,7 +104,7 @@ export default function ActivityMapPage() {
       params.set('limit', String(DEFAULT_LIMIT));
       params.set('page', '0');
       params.set('appId', String(appId));
-      if (geoSource) params.set('geoSource', geoSource);
+      // geoSource now filtered client-side, not server-side, so we can multi-select
 
       const res = await axios.get(`/api/analytics/map-center-history?${params.toString()}&_t=${Date.now()}`);
       if (res.data?.success) {
@@ -81,18 +121,86 @@ export default function ActivityMapPage() {
     } finally {
       setLoading(false);
     }
-  }, [startDate, endDate, geoSource, appId]);
+  }, [startDate, endDate, appId]);
 
   useEffect(() => {
     fetchRecords();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const renderableCount = records.filter(
-    (r) => r.userLocation?.latitude != null && r.mapCenter?.latitude != null
-  ).length;
+  // Per-IP activity counts (drives QTY threshold + IP autocomplete)
+  const ipCounts = useMemo(() => {
+    const m = new Map();
+    for (const r of records) {
+      const ip = r.ip || 'unknown';
+      m.set(ip, (m.get(ip) || 0) + 1);
+    }
+    return m;
+  }, [records]);
+
+  const ipOptions = useMemo(
+    () =>
+      Array.from(ipCounts.entries())
+        .filter(([ip]) => ip && ip !== 'unknown')
+        .sort((a, b) => b[1] - a[1])
+        .map(([ip, n]) => ({ ip, count: n })),
+    [ipCounts]
+  );
+
+  const maxIpCount = useMemo(() => {
+    let max = 1;
+    for (const n of ipCounts.values()) if (n > max) max = n;
+    return max;
+  }, [ipCounts]);
+
+  // Filtered set actually rendered on map + counted in summary
+  const filteredRecords = useMemo(() => {
+    return records.filter((r) => {
+      const userLat = r.userLocation?.latitude;
+      const userLng = r.userLocation?.longitude;
+      const mapLat = r.mapCenter?.latitude;
+      const mapLng = r.mapCenter?.longitude;
+      if (userLat == null || userLng == null || mapLat == null || mapLng == null) return false;
+
+      const source = r.userLocation?.source;
+      if (geoSources.length === 0) return false;
+      if (source && !geoSources.includes(source)) return false;
+
+      if (ipFilter && r.ip !== ipFilter) return false;
+
+      const ipCount = ipCounts.get(r.ip || 'unknown') || 0;
+      if (ipCount < minQty) return false;
+
+      if (viewportFilter && viewportBounds) {
+        if (userLat > viewportBounds.north || userLat < viewportBounds.south) return false;
+        // Naive E/W check; ignore antimeridian wrap (acceptable for our user base)
+        if (userLng > viewportBounds.east || userLng < viewportBounds.west) return false;
+      }
+
+      if (localsOnly) {
+        const dist = haversineKm(r.userLocation, r.mapCenter);
+        if (dist == null || dist > localsKm) return false;
+      }
+
+      return true;
+    });
+  }, [records, geoSources, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
 
   const mapboxConfigured = !!process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+
+  const handleSourceToggle = (_e, next) => {
+    // ToggleButtonGroup returns null when all unselected — keep at least one selected? Allow empty (hides all dots).
+    setGeoSources(next || []);
+  };
+
+  const resetFilters = () => {
+    setGeoSources(ALL_SOURCE_KEYS);
+    setMinQty(1);
+    setIpFilter('');
+    setViewportFilter(false);
+    setLocalsOnly(false);
+    setLocalsKm(50);
+  };
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -113,8 +221,9 @@ export default function ActivityMapPage() {
             </Alert>
           )}
 
-          {/* Filter bar */}
+          {/* Filter bar — two rows */}
           <Paper sx={{ p: 2, mb: 1 }}>
+            {/* Row 1: fetch controls */}
             <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }}>
               <DatePicker
                 label="Start"
@@ -128,21 +237,6 @@ export default function ActivityMapPage() {
                 onChange={(d) => isValid(d) && setEndDate(d)}
                 slotProps={{ textField: { size: 'small' } }}
               />
-              <FormControl size="small" sx={{ minWidth: 180 }}>
-                <InputLabel shrink>Geo source</InputLabel>
-                <Select
-                  value={geoSource}
-                  label="Geo source"
-                  displayEmpty
-                  notched
-                  onChange={(e) => setGeoSource(e.target.value)}
-                >
-                  <MenuItem value="">All</MenuItem>
-                  <MenuItem value="GoogleBrowser">Browser GPS</MenuItem>
-                  <MenuItem value="GoogleGeolocation">Google IP</MenuItem>
-                  <MenuItem value="IPInfoIO">IP lookup</MenuItem>
-                </Select>
-              </FormControl>
               <Button
                 variant="contained"
                 onClick={fetchRecords}
@@ -154,36 +248,115 @@ export default function ActivityMapPage() {
 
               <Box sx={{ flexGrow: 1 }} />
 
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Chip
+              <Button size="small" onClick={resetFilters} variant="outlined">
+                Reset filters
+              </Button>
+            </Stack>
+
+            <Divider sx={{ my: 1.5 }} />
+
+            {/* Row 2: client-side filters */}
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'center' }} flexWrap="wrap" useFlexGap>
+              {/* Geo source multi-select */}
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  Map-center source
+                </Typography>
+                <ToggleButtonGroup
                   size="small"
-                  icon={<GpsFixedIcon sx={{ fontSize: 14 }} />}
-                  label="Browser GPS"
-                  sx={{ bgcolor: '#2e7d32', color: '#fff' }}
-                />
-                <Chip
+                  value={geoSources}
+                  onChange={handleSourceToggle}
+                  aria-label="Geo source filter"
+                >
+                  {SOURCE_OPTIONS.map((s) => (
+                    <ToggleButton key={s.key} value={s.key} sx={{ textTransform: 'none', px: 1 }}>
+                      {s.key === 'GoogleBrowser' && <GpsFixedIcon sx={{ fontSize: 14, mr: 0.5, color: s.color }} />}
+                      {s.key === 'GoogleGeolocation' && <LocationOnIcon sx={{ fontSize: 14, mr: 0.5, color: s.color }} />}
+                      {s.key === 'IPInfoIO' && <WifiIcon sx={{ fontSize: 14, mr: 0.5, color: s.color }} />}
+                      {s.label}
+                    </ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </Box>
+
+              {/* QTY threshold */}
+              <Box sx={{ minWidth: 200, px: 1 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                  Min events per IP: <strong>{minQty}</strong>
+                </Typography>
+                <Slider
                   size="small"
-                  icon={<LocationOnIcon sx={{ fontSize: 14 }} />}
-                  label="Google IP"
-                  sx={{ bgcolor: '#1976d2', color: '#fff' }}
+                  value={minQty}
+                  onChange={(_e, v) => setMinQty(v)}
+                  min={1}
+                  max={Math.max(2, maxIpCount)}
+                  valueLabelDisplay="auto"
+                  marks={[{ value: 1, label: '1' }, { value: Math.max(2, maxIpCount), label: String(Math.max(2, maxIpCount)) }]}
+                  sx={{ mt: 1 }}
                 />
-                <Chip
-                  size="small"
-                  icon={<WifiIcon sx={{ fontSize: 14 }} />}
-                  label="IP lookup"
-                  sx={{ bgcolor: '#757575', color: '#fff' }}
+              </Box>
+
+              {/* IP filter */}
+              <Autocomplete
+                size="small"
+                options={ipOptions}
+                value={ipOptions.find((o) => o.ip === ipFilter) || null}
+                onChange={(_e, v) => setIpFilter(v?.ip || '')}
+                getOptionLabel={(o) => `${o.ip} (${o.count})`}
+                isOptionEqualToValue={(a, b) => a.ip === b.ip}
+                sx={{ minWidth: 220 }}
+                renderInput={(params) => <TextField {...params} label="IP filter" placeholder="any" />}
+                clearOnEscape
+              />
+
+              {/* Viewport toggle */}
+              <Tooltip title="Show only dots whose user-location is inside the visible map area. Refreshes on pan/zoom.">
+                <FormControlLabel
+                  control={<Switch size="small" checked={viewportFilter} onChange={(e) => setViewportFilter(e.target.checked)} />}
+                  label={
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                      <CenterFocusStrongIcon sx={{ fontSize: 16 }} />
+                      <Typography variant="body2">Viewport only</Typography>
+                    </Stack>
+                  }
                 />
-              </Stack>
+              </Tooltip>
+
+              {/* Locals-only toggle + km threshold */}
+              <Tooltip title="Show only users whose location is within N km of the map center they were viewing — i.e., people looking at where they actually are.">
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <FormControlLabel
+                    control={<Switch size="small" checked={localsOnly} onChange={(e) => setLocalsOnly(e.target.checked)} />}
+                    label={
+                      <Stack direction="row" spacing={0.5} alignItems="center">
+                        <HomeIcon sx={{ fontSize: 16 }} />
+                        <Typography variant="body2">Locals only</Typography>
+                      </Stack>
+                    }
+                  />
+                  {localsOnly && (
+                    <TextField
+                      size="small"
+                      type="number"
+                      label="km"
+                      value={localsKm}
+                      onChange={(e) => setLocalsKm(Math.max(1, Number(e.target.value) || 1))}
+                      sx={{ width: 90 }}
+                      inputProps={{ min: 1, max: 5000 }}
+                    />
+                  )}
+                </Stack>
+              </Tooltip>
             </Stack>
 
             <Box sx={{ mt: 1.5 }}>
               <Typography variant="caption" color="text.secondary">
                 Range: <strong>{isValid(startDate) ? format(startDate, 'MMM d, yyyy') : '—'}</strong> → <strong>{isValid(endDate) ? format(endDate, 'MMM d, yyyy') : '—'}</strong>
                 {' • '}
-                Showing <strong>{renderableCount}</strong> of <strong>{total.toLocaleString()}</strong> records
-                {records.length < total && ` (capped at ${DEFAULT_LIMIT} for this view)`}
+                Showing <strong>{filteredRecords.length}</strong> of <strong>{records.length}</strong> renderable / <strong>{total.toLocaleString()}</strong> total
+                {records.length < total && ` (capped at ${DEFAULT_LIMIT} per fetch)`}
                 {' • '}
-                Lines connect user → map center
+                {ipCounts.size} distinct IPs in fetched window
               </Typography>
             </Box>
           </Paper>
@@ -195,8 +368,6 @@ export default function ActivityMapPage() {
           )}
         </Box>
 
-        {/* Map area — rocking-chair layout: relative parent + absolute-fill child guarantees the
-            MapContainer always has a concrete sized box to mount into, regardless of flex timing. */}
         <Box sx={{
           flexGrow: 1,
           position: 'relative',
@@ -218,7 +389,10 @@ export default function ActivityMapPage() {
             </Box>
           )}
           <Box sx={{ position: 'absolute', inset: 0 }}>
-            <ActivityMapView records={records} />
+            <ActivityMapView
+              records={filteredRecords}
+              onBoundsChange={setViewportBounds}
+            />
           </Box>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
Adds 5 client-side filters to /dashboard/analytics/activity-map (CALOPS-52 base). FE-only, no BE changes.

- **Source** — multi-select toggle (Browser GPS / Google IP / IP lookup); was single-select fetch param, now FE filter
- **QTY threshold** — slider, min events per IP (1 → max in fetched window)
- **IP filter** — autocomplete from fetched records, sorted by count
- **Viewport only** — toggle that snaps to current Leaflet bounds (pan/zoom auto-refresh via new BoundsReporter)
- **Locals only** — toggle + km input; Haversine user-vs-mapCenter distance

Layout: two-row Filter Paper. Summary chip shows filtered/renderable/total + distinct IP count.

## Files
- `src/app/dashboard/analytics/activity-map/page.js` (+212 / −49)
- `src/app/dashboard/analytics/activity-map/ActivityMapView.js` (+22 / −1, BoundsReporter)

## Test plan
- Merge to TEST → Vercel auto-deploys → manually verify filters on calops-test
- Visual checks: source toggles, QTY slider, IP autocomplete, viewport-snap on pan/zoom, locals-only with km threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)