### PR TITLE
CALOPS-57b: Activity Heatmaps section + heatmap defaults (1M / all / DOM / Boston)

### DIFF
--- a/src/app/dashboard/analytics/event-creation/page.js
+++ b/src/app/dashboard/analytics/event-creation/page.js
@@ -118,7 +118,7 @@ export default function EventCreationPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [data, setData] = useState(null);
-  const [timeRange, setTimeRange] = useState('3M');
+  const [timeRange, setTimeRange] = useState('1M'); // CALOPS-57b: default 1M
   const [timezoneMode, setTimezoneMode] = useState('boston'); // 'boston' or 'local'
   const [viewMode, setViewMode] = useState('dom'); // Default to DOM view
   const [sourceFilter, setSourceFilter] = useState('all'); // Default to All events
@@ -229,7 +229,7 @@ export default function EventCreationPage() {
         gap: 2
       }}>
         <Typography variant="h4">
-          Events Activity — Creation
+          Events Heatmap
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
           {/* Time Range */}

--- a/src/app/dashboard/analytics/visitor-heatmap/page.js
+++ b/src/app/dashboard/analytics/visitor-heatmap/page.js
@@ -113,8 +113,8 @@ export default function VisitorHeatmapPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [heatmapData, setHeatmapData] = useState(null);
-  const [timeRange, setTimeRange] = useState('3M');
-  const [sourceFilter, setSourceFilter] = useState('visitors'); // Default to SITE access
+  const [timeRange, setTimeRange] = useState('1M'); // CALOPS-57b: default 1M
+  const [sourceFilter, setSourceFilter] = useState('all'); // CALOPS-57b: default "all"
   const [timezoneMode, setTimezoneMode] = useState('boston');
   const [viewMode, setViewMode] = useState('dom'); // Default to DOM view
 
@@ -248,7 +248,7 @@ export default function VisitorHeatmapPage() {
         flexWrap: 'wrap',
         gap: 2
       }}>
-        <Typography variant="h4">Site Activity</Typography>
+        <Typography variant="h4">Site Heatmap</Typography>
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
           <ToggleButtonGroup
             value={timeRange}

--- a/src/components/AdminLayout.js
+++ b/src/components/AdminLayout.js
@@ -48,17 +48,15 @@ import StorageIcon from '@mui/icons-material/Storage';
 import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
 import MapIcon from '@mui/icons-material/Map';
 
-// Navigation — Site Activity (top-level standalone, no section)
-const siteActivityNav = {
-  name: 'Site Activity',
-  icon: <GridOnIcon />,
-  href: '/dashboard/analytics/visitor-heatmap',
-};
+// Navigation — Activity Heatmaps section (groups all heatmap-style views)
+const activityHeatmapItems = [
+  { name: 'Site Heatmap',   icon: <GridOnIcon />, href: '/dashboard/analytics/visitor-heatmap' },
+  { name: 'Events Heatmap', icon: <GridOnIcon />, href: '/dashboard/analytics/event-creation' },
+];
 
 // Navigation — Events Activity section
 const eventsActivityItems = [
-  { name: 'Creation',    icon: <GridOnIcon />, href: '/dashboard/analytics/event-creation' },
-  { name: 'Audit Trail', icon: <EventIcon />,  href: '/dashboard/analytics/event-activity' },
+  { name: 'Audit Trail', icon: <EventIcon />, href: '/dashboard/analytics/event-activity' },
 ];
 
 // Navigation — User Activity section
@@ -192,14 +190,19 @@ export default function AdminLayout({ children }) {
 
       <Divider sx={{ my: 1 }} />
 
-      {/* Site Activity — standalone top-level link (no section header, only one page) */}
+      {/* Activity Heatmaps */}
+      <Typography variant="overline" sx={{ px: 2, pt: 1, color: 'text.secondary', fontWeight: 'bold' }}>
+        Activity Heatmaps
+      </Typography>
       <List dense>
-        <ListItem disablePadding>
-          <ListItemButton component="a" href={siteActivityNav.href}>
-            <ListItemIcon>{siteActivityNav.icon}</ListItemIcon>
-            <ListItemText primary={siteActivityNav.name} />
-          </ListItemButton>
-        </ListItem>
+        {activityHeatmapItems.map((item) => (
+          <ListItem key={item.name} disablePadding>
+            <ListItemButton component="a" href={item.href}>
+              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.name} />
+            </ListItemButton>
+          </ListItem>
+        ))}
       </List>
 
       <Divider sx={{ my: 1 }} />


### PR DESCRIPTION
## Summary
Tweaks on top of CALOPS-57 per Toby 2026-05-12 hub.

## Menu structure
Introduce **ACTIVITY HEATMAPS** section grouping both heatmap-style pages:
- ACTIVITY HEATMAPS  ← NEW section
  - Site Heatmap  (was standalone "Site Activity"; visitor-heatmap route)
  - Events Heatmap  (was "Events Activity — Creation"; event-creation route)
- EVENTS ACTIVITY  (narrows to single Audit Trail)
- USER ACTIVITY / ERRORS / DATA — unchanged

## Default heatmap filter values (Toby spec: 1M / all / DOM / Boston)
- timeRange: `'3M'` → **`'1M'`** (both heatmaps)
- visitor-heatmap sourceFilter: `'visitors'` → **`'all'`**
- viewMode: already `'dom'` ✓
- timezoneMode: already `'boston'` ✓

## Page-heading renames
- "Site Activity" → **"Site Heatmap"**
- "Events Activity — Creation" → **"Events Heatmap"**

## Files changed (3)
- `src/components/AdminLayout.js` (nav restructure)
- `src/app/dashboard/analytics/visitor-heatmap/page.js` (2 default-value flips + heading)
- `src/app/dashboard/analytics/event-creation/page.js` (1 default-value flip + heading)

FE-only, no BE changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)