### PR TITLE
CalOps PROD-promote: v1.11.0 → v1.11.1 (CALOPS-58 Activity Map enhancements) — 🟢 HITM-MERGE READY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -1,18 +1,50 @@
 'use client';
 
 import { Fragment, useEffect } from 'react';
-import { MapContainer, TileLayer, CircleMarker, Circle, Polyline, Popup, useMap, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, CircleMarker, Circle, Polyline, Popup, Tooltip, useMap, useMapEvents } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 
 const USA_CENTER = [39.5, -98.5];
 const USA_ZOOM = 4;
 
-// Two-color scheme: user location vs map center
-const USER_COLOR = '#1976d2';   // blue
+// CALOPS-58 Mod 1: color-by-source for user dots (restored from CALOPS-52 v1).
+const SOURCE_COLORS = {
+  GoogleBrowser:     '#2e7d32', // green — Browser GPS
+  GoogleGeolocation: '#1976d2', // blue — Google IP
+  IPInfoIO:          '#757575', // gray — IP lookup
+};
+const DEFAULT_USER_COLOR = '#1976d2';
 const CENTER_COLOR = '#d32f2f'; // red
-const LINE_COLOR = '#757575';   // gray (connecting line)
+const LINE_COLOR   = '#757575'; // gray
 
-// Fix Leaflet default-icon paths once on the client
+// CALOPS-58 Mod 2: default accuracy ring radius (meters) for non-GPS sources.
+// GPS uses real browserGps.accuracy.
+const DEFAULT_ACCURACY_M = {
+  GoogleGeolocation: 5000,   // Google IP geolocation ~5 km typical
+  IPInfoIO:          50000,  // IP lookup ~50 km typical
+};
+
+function haversineKm(aLat, aLng, bLat, bLng) {
+  if (aLat == null || aLng == null || bLat == null || bLng == null) return null;
+  const R = 6371;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(bLat - aLat);
+  const dLng = toRad(bLng - aLng);
+  const lat1 = toRad(aLat);
+  const lat2 = toRad(bLat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+function formatKm(km) {
+  if (km == null) return '—';
+  if (km < 1) return `${Math.round(km * 1000)} m`;
+  if (km < 10) return `${km.toFixed(1)} km`;
+  return `${Math.round(km)} km`;
+}
+
 function FixLeafletIcons() {
   useEffect(() => {
     (async () => {
@@ -57,41 +89,55 @@ export default function ActivityMapView({ records, onBoundsChange }) {
       {records.map((rec) => {
         const userLat = rec.userLocation?.latitude;
         const userLng = rec.userLocation?.longitude;
-        const mapLat = rec.mapCenter?.latitude;
-        const mapLng = rec.mapCenter?.longitude;
+        const mapLat  = rec.mapCenter?.latitude;
+        const mapLng  = rec.mapCenter?.longitude;
         if (userLat == null || userLng == null || mapLat == null || mapLng == null) return null;
 
-        const source = rec.userLocation?.source;
-        const accuracy = rec.userLocation?.browserGps?.accuracy;
-        const isGps = source === 'GoogleBrowser' && accuracy != null;
+        const source   = rec.userLocation?.source;
+        const userColor = SOURCE_COLORS[source] || DEFAULT_USER_COLOR;
+        const gpsAccuracy = rec.userLocation?.browserGps?.accuracy;
+        const ringRadius = source === 'GoogleBrowser'
+          ? gpsAccuracy
+          : (DEFAULT_ACCURACY_M[source] ?? null);
+        const accuracyLabel = source === 'GoogleBrowser' && gpsAccuracy != null
+          ? `±${Math.round(gpsAccuracy)} m (GPS)`
+          : DEFAULT_ACCURACY_M[source] != null
+            ? `~${Math.round(DEFAULT_ACCURACY_M[source] / 1000)} km (default)`
+            : 'unknown';
         const userId = rec.firebaseUserId?.slice(-8) || (rec.ip ? `ip:${rec.ip}` : 'anon');
+        const distKm = haversineKm(userLat, userLng, mapLat, mapLng);
+        const distLabel = formatKm(distKm);
 
         return (
           <Fragment key={rec.id}>
-            {/* User location: blue dot. Optional accuracy ring when GPS. */}
-            {isGps && (
+            {/* Accuracy ring — uncertainty cloud, sized by source */}
+            {ringRadius != null && (
               <Circle
                 center={[userLat, userLng]}
-                radius={accuracy}
-                pathOptions={{ color: USER_COLOR, fillColor: USER_COLOR, fillOpacity: 0.1, weight: 1 }}
+                radius={ringRadius}
+                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.08, weight: 1 }}
                 interactive={false}
               />
             )}
+
+            {/* User location dot (color = source) */}
             <CircleMarker
               center={[userLat, userLng]}
               radius={5}
-              pathOptions={{ color: USER_COLOR, fillColor: USER_COLOR, fillOpacity: 0.85, weight: 1 }}
+              pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.85, weight: 1 }}
             >
               <Popup>
                 <div style={{ fontSize: 12 }}>
                   <strong>User:</strong> {userId}<br />
-                  <strong>Source:</strong> {source || 'unknown'}{isGps ? ` (±${Math.round(accuracy)}m)` : ''}<br />
+                  <strong>Source:</strong> {source || 'unknown'}<br />
+                  <strong>Accuracy:</strong> {accuracyLabel}<br />
+                  <strong>Distance to viewed center:</strong> {distLabel}<br />
                   <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
                 </div>
               </Popup>
             </CircleMarker>
 
-            {/* Map center: red dot */}
+            {/* Map center dot (red) */}
             <CircleMarker
               center={[mapLat, mapLng]}
               radius={5}
@@ -101,16 +147,21 @@ export default function ActivityMapView({ records, onBoundsChange }) {
                 <div style={{ fontSize: 12 }}>
                   <strong>Map center viewed by</strong> {userId}<br />
                   <strong>At:</strong> {mapLat.toFixed(4)}, {mapLng.toFixed(4)}<br />
+                  <strong>Distance from user:</strong> {distLabel}<br />
                   <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
                 </div>
               </Popup>
             </CircleMarker>
 
-            {/* Connecting line user → mapCenter */}
+            {/* Connecting line user → mapCenter with hover distance tooltip */}
             <Polyline
               positions={[[userLat, userLng], [mapLat, mapLng]]}
               pathOptions={{ color: LINE_COLOR, weight: 1, opacity: 0.4, dashArray: '4 4' }}
-            />
+            >
+              <Tooltip sticky direction="center" opacity={0.9}>
+                <span style={{ fontSize: 11 }}>{distLabel}</span>
+              </Tooltip>
+            </Polyline>
           </Fragment>
         );
       })}
@@ -120,7 +171,6 @@ export default function ActivityMapView({ records, onBoundsChange }) {
   );
 }
 
-// If no records, ensure we stay on USA center (avoids any auto-fit weirdness from prior renders)
 function RecenterIfEmpty({ hasRecords }) {
   const map = useMap();
   useEffect(() => {
@@ -131,9 +181,6 @@ function RecenterIfEmpty({ hasRecords }) {
   return null;
 }
 
-// Force the map to recompute size after mount — fixes the case where a flex parent
-// hasn't finished its layout pass when MapContainer first measures itself, leaving
-// the map at 0×0 with no tiles loaded. Run on mount + once after a short delay.
 function InvalidateOnMount() {
   const map = useMap();
   useEffect(() => {
@@ -145,8 +192,6 @@ function InvalidateOnMount() {
   return null;
 }
 
-// Reports current viewport bounds to parent on mount + after pan/zoom.
-// Plain object so the parent doesn't have to handle Leaflet types.
 function BoundsReporter({ onBoundsChange }) {
   const emit = (map) => {
     if (!onBoundsChange) return;

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -46,7 +46,10 @@ const ActivityMapView = dynamic(() => import('./ActivityMapView'), {
   ),
 });
 
-const DEFAULT_LIMIT = 200;
+// BE caps at 200/page; paginate client-side to reach TARGET_TOTAL.
+const PAGE_SIZE = 200;
+const TARGET_TOTAL = 1000;
+const MAX_PAGES = TARGET_TOTAL / PAGE_SIZE;
 
 const SOURCE_OPTIONS = [
   { key: 'GoogleBrowser',     label: 'Browser GPS', color: '#2e7d32' },
@@ -98,21 +101,30 @@ export default function ActivityMapPage() {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams();
-      params.set('startDate', startDate.toISOString());
-      params.set('endDate', endDate.toISOString());
-      params.set('limit', String(DEFAULT_LIMIT));
-      params.set('page', '0');
-      params.set('appId', String(appId));
-      // geoSource now filtered client-side, not server-side, so we can multi-select
+      // CALOPS-58 Mod 4: paginate 5 × 200 = 1000 cap (BE caps at 200/call).
+      const all = [];
+      let beReportedTotal = 0;
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const params = new URLSearchParams();
+        params.set('startDate', startDate.toISOString());
+        params.set('endDate', endDate.toISOString());
+        params.set('limit', String(PAGE_SIZE));
+        params.set('page', String(page));
+        params.set('appId', String(appId));
 
-      const res = await axios.get(`/api/analytics/map-center-history?${params.toString()}&_t=${Date.now()}`);
-      if (res.data?.success) {
-        setRecords(res.data.data || []);
-        setTotal(res.data.pagination?.total || 0);
-      } else {
-        throw new Error(res.data?.error || 'Failed to fetch map-center records');
+        const res = await axios.get(`/api/analytics/map-center-history?${params.toString()}&_t=${Date.now()}`);
+        if (!res.data?.success) {
+          throw new Error(res.data?.error || 'Failed to fetch map-center records');
+        }
+        const batch = res.data.data || [];
+        all.push(...batch);
+        if (page === 0) {
+          beReportedTotal = res.data.pagination?.total || 0;
+        }
+        if (batch.length < PAGE_SIZE) break; // exhausted source
       }
+      setRecords(all);
+      setTotal(beReportedTotal);
     } catch (err) {
       console.error('activity-map fetch error', err);
       setError(err.message || 'Fetch failed');
@@ -354,7 +366,7 @@ export default function ActivityMapPage() {
                 Range: <strong>{isValid(startDate) ? format(startDate, 'MMM d, yyyy') : '—'}</strong> → <strong>{isValid(endDate) ? format(endDate, 'MMM d, yyyy') : '—'}</strong>
                 {' • '}
                 Showing <strong>{filteredRecords.length}</strong> of <strong>{records.length}</strong> renderable / <strong>{total.toLocaleString()}</strong> total
-                {records.length < total && ` (capped at ${DEFAULT_LIMIT} per fetch)`}
+                {records.length < total && ` (capped at ${TARGET_TOTAL} for this view; ${PAGE_SIZE}/page × ${MAX_PAGES} pages)`}
                 {' • '}
                 {ipCounts.size} distinct IPs in fetched window
               </Typography>


### PR DESCRIPTION
## 🟢 HITM-MERGE READY NOW (Quinn-ratified beat-54 at 2026-05-13T00:28Z)

**Toby — required phrase to authorize:** `DEPLOY-PROD` (provided 22:53Z). Then click "Merge pull request" in GitHub UI.

## Scope (single ticket)
**CALOPS-58 — Activity Map enhancements** (4 mods, FE-only, no BE changes, Toby-approved 22:38Z + Toby-passed on TEST 22:48Z)

| Mod | What |
|---|---|
| 1 | Color-by-source on user dots: GoogleBrowser=green / GoogleGeolocation=blue / IPInfoIO=gray. Restores source-color encoding from CALOPS-52 v1. Red center dots unchanged. |
| 2 | Accuracy ring for all sources: GPS uses real browserGps.accuracy; Google IP defaults 5km; IP lookup defaults 50km. Low opacity 0.08 — visualizes uncertainty without dominating. |
| 3 | Distance label on user → center polyline: hover Tooltip shows Haversine km; also surfaced in user popup + center popup. |
| 4 | Cap raised 200 → 1000 with client-side pagination (BE caps at 200/page; loop 5 pages, early-break on incomplete batch). |

Mod 5 (Google-IP-as-master) HELD per Toby; revisit later.

## Files changed (3, all FE)
- `src/app/dashboard/analytics/activity-map/page.js` — pagination + count display
- `src/app/dashboard/analytics/activity-map/ActivityMapView.js` — color-by-source + accuracy rings + distance tooltip
- `package.json` / `package-lock.json` — version bump

**Diff:** +98 / −41 across the two analytics-map files + version bump.

## CRK (6-dim, Quinn beat-44 hard pre-ratification format)

| Dim | Value |
|---|---|
| **Confidence** | 95% (FE-only visual enhancement; tested on TEST; Toby user-verified) |
| **Scope** | Single-ticket CALOPS-58; 4 mods; no BE changes; no calendar substrate touch; no event-origin reporting |
| **Risks** | (a) Accuracy rings at low zoom may render as large translucent blobs (especially IP lookup's 50km default); opacity 0.08 mitigates visual dominance. (b) 1000-cap fetch increases page-load latency from 1 BE call → up to 5; client-side aggregation; UI shows loading state throughout. (c) Color-by-source change is reversible-by-revert; matches existing filter legend chips already on the page. |
| **Knowledge gaps** | None material. Tier-3 admin operational surface (Quinn beat-26 frame: gate 6 N/A); no calendar invariant touched. |
| **Regression test** | Vercel TEST build green (deploy `calops-test-52ka33xix-ybotmans-projects.vercel.app` Ready); `/dashboard/analytics/activity-map` HTTP 200 / 16.9KB shell on TEST; `/api/version` returns `1.11.1` confirming TEST head; Toby user-verified rendering on TEST 22:48Z ("passed"). |
| **Backout** | `git revert <merge-sha>` on PROD → Vercel auto-deploy back to v1.11.0 in ~1min. Atomic single-merge-commit. No data side-effects. |

## 4-precondition gate (beat-39 + Gotan beat-49 MERGEABILITY addition)

- ✅ **PLAN** — CALOPS-58 JIRA + this PR body + commit message
- ✅ **TEST** — Vercel build green + TEST deploy verified + Toby user-verification on TEST
- ✅ **ROLLBACK** — atomic single-revert documented above
- ✅ **MERGEABILITY** — pre-flight `git merge-tree` check returned ZERO conflicts; TEST is fast-forward over PROD (verified 22:54Z)

## 6-gate CRK ratification (Quinn beat-44 protocol)

- ✅ TEST sweep — Vercel build + structural validation + Toby user-test
- ✅ CRK 6-dim — above
- ✅ Regression test — vercel-curl smoke on TEST clean
- ⚪ Tier-1/Tier-2 surface evidence — N/A at Tier-3 (admin operational, not user-paramount per Gotan beat-24)
- ✅ Semantic-consistency + product-intent — no event-origin/visibility/quality semantic touch; Toby direct product approval on each mod
- ⚪ Calendar Invariants applicability — N/A at Tier-3 admin

## Visual smoke checklist (Toby at HITM-merge)

After Vercel PROD auto-deploys (~60-90s post-merge):
1. Open `https://www.cal-ops.org/dashboard/analytics/activity-map`
2. Verify: user dots colored per source (green/blue/gray); red center dots unchanged
3. Verify: low-opacity rings around user dots, sized by source uncertainty
4. Verify: hover the gray dashed line between a user and a center → km distance tooltip
5. Verify: count summary shows fetched/renderable/total (up to 1000)

If anything regresses → `git revert <merge-sha>` on PROD → ~60s auto-deploy back to v1.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
