### PR TITLE
CALOPS-58f: Activity Map z-order fix + source-filter SOFT semantic

### DIFF
--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -61,7 +61,15 @@ function FixLeafletIcons() {
   return null;
 }
 
-export default function ActivityMapView({ records, onBoundsChange }) {
+// CALOPS-58f: source filter is a SOFT filter — toggling off a source hides the user-side
+// rendering (dot/ring/popup) but the map-center dot + connecting line for that record stay
+// visible. "Where people looked" (red center) is independent of "how their location was
+// resolved" (source).
+export default function ActivityMapView({ records, onBoundsChange, geoSources }) {
+  const sourceSet = geoSources instanceof Set
+    ? geoSources
+    : Array.isArray(geoSources) ? new Set(geoSources) : null;
+  const sourceVisible = (src) => sourceSet == null ? true : sourceSet.has(src);
   const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
   const tileUrl = mapboxToken
     ? `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxToken}`
@@ -127,11 +135,13 @@ export default function ActivityMapView({ records, onBoundsChange }) {
           </Popup>
         );
 
+        const showUserSide = sourceVisible(source);
+
         return (
           <Fragment key={rec.id}>
-            {/* Accuracy ring — uncertainty cloud, sized by source. For imprecise sources, this
-                IS the only marker (popup attached). For precise sources, paired with center dot. */}
-            {ringRadius != null && (
+            {/* User-side rendering (ring + dot) — only when source filter shows this source.
+                Red center + line are ALWAYS rendered regardless of source filter. */}
+            {showUserSide && ringRadius != null && (
               <Circle
                 center={[userLat, userLng]}
                 radius={ringRadius}
@@ -147,18 +157,8 @@ export default function ActivityMapView({ records, onBoundsChange }) {
               </Circle>
             )}
 
-            {/* Solid user dot — only for precise (GPS) sources */}
-            {isPrecise && (
-              <CircleMarker
-                center={[userLat, userLng]}
-                radius={5}
-                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.85, weight: 1 }}
-              >
-                {userPopupBody}
-              </CircleMarker>
-            )}
-
-            {/* Map center dot (red) */}
+            {/* Map center dot (red) — ALWAYS rendered; drawn BEFORE GPS dot so when user-GPS
+                coincides with map-center, the green user dot stays visible on top. */}
             <CircleMarker
               center={[mapLat, mapLng]}
               radius={5}
@@ -174,7 +174,19 @@ export default function ActivityMapView({ records, onBoundsChange }) {
               </Popup>
             </CircleMarker>
 
-            {/* Connecting line user → mapCenter with hover distance tooltip */}
+            {/* Solid user dot — only for precise GPS sources; drawn AFTER red center so it
+                stays on top of overlapping red. White stroke for visibility against red. */}
+            {showUserSide && isPrecise && (
+              <CircleMarker
+                center={[userLat, userLng]}
+                radius={6}
+                pathOptions={{ color: '#ffffff', fillColor: userColor, fillOpacity: 1.0, weight: 1.5 }}
+              >
+                {userPopupBody}
+              </CircleMarker>
+            )}
+
+            {/* Connecting line user → mapCenter — ALWAYS rendered (relationship is source-independent) */}
             <Polyline
               positions={[[userLat, userLng], [mapLat, mapLng]]}
               pathOptions={{ color: LINE_COLOR, weight: 1, opacity: 0.4, dashArray: '4 4' }}

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -174,9 +174,9 @@ export default function ActivityMapPage() {
       const mapLng = r.mapCenter?.longitude;
       if (userLat == null || userLng == null || mapLat == null || mapLng == null) return false;
 
-      const source = r.userLocation?.source;
-      if (geoSources.length === 0) return false;
-      if (source && !geoSources.includes(source)) return false;
+      // CALOPS-58f: source filter is a SOFT filter (applied in ActivityMapView for the
+      // user-side rendering only). Red center + line stay visible regardless of source toggle.
+      // Hard filters (qty / ip / viewport / locals) still drop the whole record below.
 
       if (ipFilter && r.ip !== ipFilter) return false;
 
@@ -196,7 +196,7 @@ export default function ActivityMapPage() {
 
       return true;
     });
-  }, [records, geoSources, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
+  }, [records, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
 
   const mapboxConfigured = !!process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
@@ -404,6 +404,7 @@ export default function ActivityMapPage() {
             <ActivityMapView
               records={filteredRecords}
               onBoundsChange={setViewportBounds}
+              geoSources={geoSources}
             />
           </Box>
         </Box>


### PR DESCRIPTION
Per Toby 2026-05-13. Two FE-only fixes: (1) GPS dot z-order so green stays visible on user-GPS = map-center overlap; (2) source filter is SOFT — toggling off a source only hides user-side; red center + line stay visible regardless.