### PR TITLE
v1.11.2: bump for CalOps PROD-promote (CALOPS-58e + CALOPS-58f)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",


### PR DESCRIPTION
Patch bump 1.11.1 → 1.11.2 for CalOps PROD-promote (visual enhancements on existing CALOPS-58 surface).