### PR TITLE
CalOps PROD-promote: v1.11.1 → v1.11.2 (CALOPS-58e + CALOPS-58f Activity Map visual) — 🟢 HITM-MERGE READY (DEPLOY-PROD received)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "master-calendar-operations",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -61,7 +61,15 @@ function FixLeafletIcons() {
   return null;
 }
 
-export default function ActivityMapView({ records, onBoundsChange }) {
+// CALOPS-58f: source filter is a SOFT filter — toggling off a source hides the user-side
+// rendering (dot/ring/popup) but the map-center dot + connecting line for that record stay
+// visible. "Where people looked" (red center) is independent of "how their location was
+// resolved" (source).
+export default function ActivityMapView({ records, onBoundsChange, geoSources }) {
+  const sourceSet = geoSources instanceof Set
+    ? geoSources
+    : Array.isArray(geoSources) ? new Set(geoSources) : null;
+  const sourceVisible = (src) => sourceSet == null ? true : sourceSet.has(src);
   const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
   const tileUrl = mapboxToken
     ? `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxToken}`
@@ -127,11 +135,13 @@ export default function ActivityMapView({ records, onBoundsChange }) {
           </Popup>
         );
 
+        const showUserSide = sourceVisible(source);
+
         return (
           <Fragment key={rec.id}>
-            {/* Accuracy ring — uncertainty cloud, sized by source. For imprecise sources, this
-                IS the only marker (popup attached). For precise sources, paired with center dot. */}
-            {ringRadius != null && (
+            {/* User-side rendering (ring + dot) — only when source filter shows this source.
+                Red center + line are ALWAYS rendered regardless of source filter. */}
+            {showUserSide && ringRadius != null && (
               <Circle
                 center={[userLat, userLng]}
                 radius={ringRadius}
@@ -147,18 +157,8 @@ export default function ActivityMapView({ records, onBoundsChange }) {
               </Circle>
             )}
 
-            {/* Solid user dot — only for precise (GPS) sources */}
-            {isPrecise && (
-              <CircleMarker
-                center={[userLat, userLng]}
-                radius={5}
-                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.85, weight: 1 }}
-              >
-                {userPopupBody}
-              </CircleMarker>
-            )}
-
-            {/* Map center dot (red) */}
+            {/* Map center dot (red) — ALWAYS rendered; drawn BEFORE GPS dot so when user-GPS
+                coincides with map-center, the green user dot stays visible on top. */}
             <CircleMarker
               center={[mapLat, mapLng]}
               radius={5}
@@ -174,7 +174,19 @@ export default function ActivityMapView({ records, onBoundsChange }) {
               </Popup>
             </CircleMarker>
 
-            {/* Connecting line user → mapCenter with hover distance tooltip */}
+            {/* Solid user dot — only for precise GPS sources; drawn AFTER red center so it
+                stays on top of overlapping red. White stroke for visibility against red. */}
+            {showUserSide && isPrecise && (
+              <CircleMarker
+                center={[userLat, userLng]}
+                radius={6}
+                pathOptions={{ color: '#ffffff', fillColor: userColor, fillOpacity: 1.0, weight: 1.5 }}
+              >
+                {userPopupBody}
+              </CircleMarker>
+            )}
+
+            {/* Connecting line user → mapCenter — ALWAYS rendered (relationship is source-independent) */}
             <Polyline
               positions={[[userLat, userLng], [mapLat, mapLng]]}
               pathOptions={{ color: LINE_COLOR, weight: 1, opacity: 0.4, dashArray: '4 4' }}

--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -8,10 +8,11 @@ const USA_CENTER = [39.5, -98.5];
 const USA_ZOOM = 4;
 
 // CALOPS-58 Mod 1: color-by-source for user dots (restored from CALOPS-52 v1).
+// CALOPS-58e: IPInfoIO darkened for better visibility on the OSM/Mapbox tile palette.
 const SOURCE_COLORS = {
   GoogleBrowser:     '#2e7d32', // green — Browser GPS
   GoogleGeolocation: '#1976d2', // blue — Google IP
-  IPInfoIO:          '#757575', // gray — IP lookup
+  IPInfoIO:          '#424242', // dark gray — IP lookup (was #757575)
 };
 const DEFAULT_USER_COLOR = '#1976d2';
 const CENTER_COLOR = '#d32f2f'; // red
@@ -108,34 +109,54 @@ export default function ActivityMapView({ records, onBoundsChange }) {
         const distKm = haversineKm(userLat, userLng, mapLat, mapLng);
         const distLabel = formatKm(distKm);
 
+        // CALOPS-58e: precise sources (GPS) render dot+ring; imprecise sources (Google IP,
+        // IP lookup) render only the translucent uncertainty circle — the circle IS the marker.
+        // Avoids false-precision of a small dot at the centroid of a 5-50 km uncertainty cloud.
+        const isPrecise = source === 'GoogleBrowser';
+        const ringOpacity = isPrecise ? 0.12 : 0.20;
+
+        const userPopupBody = (
+          <Popup>
+            <div style={{ fontSize: 12 }}>
+              <strong>User:</strong> {userId}<br />
+              <strong>Source:</strong> {source || 'unknown'}<br />
+              <strong>Accuracy:</strong> {accuracyLabel}<br />
+              <strong>Distance to viewed center:</strong> {distLabel}<br />
+              <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
+            </div>
+          </Popup>
+        );
+
         return (
           <Fragment key={rec.id}>
-            {/* Accuracy ring — uncertainty cloud, sized by source */}
+            {/* Accuracy ring — uncertainty cloud, sized by source. For imprecise sources, this
+                IS the only marker (popup attached). For precise sources, paired with center dot. */}
             {ringRadius != null && (
               <Circle
                 center={[userLat, userLng]}
                 radius={ringRadius}
-                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.08, weight: 1 }}
-                interactive={false}
-              />
+                pathOptions={{
+                  color: userColor,
+                  fillColor: userColor,
+                  fillOpacity: ringOpacity,
+                  weight: 1,
+                }}
+                interactive={!isPrecise}
+              >
+                {!isPrecise && userPopupBody}
+              </Circle>
             )}
 
-            {/* User location dot (color = source) */}
-            <CircleMarker
-              center={[userLat, userLng]}
-              radius={5}
-              pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.85, weight: 1 }}
-            >
-              <Popup>
-                <div style={{ fontSize: 12 }}>
-                  <strong>User:</strong> {userId}<br />
-                  <strong>Source:</strong> {source || 'unknown'}<br />
-                  <strong>Accuracy:</strong> {accuracyLabel}<br />
-                  <strong>Distance to viewed center:</strong> {distLabel}<br />
-                  <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
-                </div>
-              </Popup>
-            </CircleMarker>
+            {/* Solid user dot — only for precise (GPS) sources */}
+            {isPrecise && (
+              <CircleMarker
+                center={[userLat, userLng]}
+                radius={5}
+                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.85, weight: 1 }}
+              >
+                {userPopupBody}
+              </CircleMarker>
+            )}
 
             {/* Map center dot (red) */}
             <CircleMarker

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -174,9 +174,9 @@ export default function ActivityMapPage() {
       const mapLng = r.mapCenter?.longitude;
       if (userLat == null || userLng == null || mapLat == null || mapLng == null) return false;
 
-      const source = r.userLocation?.source;
-      if (geoSources.length === 0) return false;
-      if (source && !geoSources.includes(source)) return false;
+      // CALOPS-58f: source filter is a SOFT filter (applied in ActivityMapView for the
+      // user-side rendering only). Red center + line stay visible regardless of source toggle.
+      // Hard filters (qty / ip / viewport / locals) still drop the whole record below.
 
       if (ipFilter && r.ip !== ipFilter) return false;
 
@@ -196,7 +196,7 @@ export default function ActivityMapPage() {
 
       return true;
     });
-  }, [records, geoSources, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
+  }, [records, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
 
   const mapboxConfigured = !!process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
@@ -404,6 +404,7 @@ export default function ActivityMapPage() {
             <ActivityMapView
               records={filteredRecords}
               onBoundsChange={setViewportBounds}
+              geoSources={geoSources}
             />
           </Box>
         </Box>


### PR DESCRIPTION
## 🟢 HITM-MERGE READY (Toby DEPLOY-PROD received 06:13Z; pending Quinn ratification)

## Scope (2 tickets, sequential visual enhancements on CALOPS-58 surface)
- **CALOPS-58e** — Transparent-circle treatment for imprecise sources (Google IP, IP lookup): drop solid centroid dot; render only translucent accuracy Circle. Darken IPInfoIO fill #757575→#424242. Ring opacity 0.08→0.20 for non-GPS visibility.
- **CALOPS-58f** — Two follow-on fixes per Toby iterative feedback:
  - **Z-order swap**: GPS green dot now drawn AFTER red center dot, staying visible when user-GPS coincides with map-center (initial-mount scenario; 3 of 10 GPS records had exact overlap). GPS dot radius 5→6 + white stroke for contrast.
  - **Source filter SOFT semantic**: toggling off "Browser GPS" / "Google IP" / "IP lookup" now hides only the user-side rendering (ring + dot). Red center + connecting line STAY visible regardless of source toggle. Red represents "where people were looking" — independent of how user location was resolved.

## Files changed
- `src/app/dashboard/analytics/activity-map/ActivityMapView.js` (visual logic)
- `src/app/dashboard/analytics/activity-map/page.js` (source filter moved from hard to soft)
- `package.json` / `package-lock.json` (1.11.1 → 1.11.2)

**Diff:** +63 / -22 across the two analytics-map files + version bump.

## 6-dim CRK (Quinn beat-44 hard pre-ratification format)

| Dim | Value |
|---|---|
| **Confidence** | 95% (FE-only visual on existing CALOPS-58 surface; both fixes Toby-iterated on TEST; no BE; no calendar substrate) |
| **Scope** | Tier-3 admin (Activity Map visualization); 2 commits sequential build-on CALOPS-58 PROD-live since 22:53Z |
| **Risks** | LOW. (a) Source-filter semantic CHANGE — previously hard-filtered records (whole record dropped); now soft (user-side only). Behavior change visible to admin user. (b) Z-order swap could in theory reveal a dot drawn at unexpected position if logic regressed — verified by Toby's TEST iteration (he saw the fix work). (c) GPS dot bump from 5→6 radius + white stroke is purely visual; no functional impact. |
| **Knowledge gaps** | None material. Toby-iterated multiple TEST cycles tonight; both fixes user-verified on TEST. |
| **Regression test** | Vercel TEST build green for both merges (CALOPS-58e + CALOPS-58f); Toby user-iterated and validated the visuals on TEST. |
| **Backout** | `git revert <merge-sha>` on PROD → Vercel auto-deploys back to v1.11.1 in ~1min. Atomic single-merge-commit. No data side-effects. |

## 4-precondition gate (Gotan beat-49)
- ✅ **PLAN** — CALOPS-58e + 58f JIRA-class tickets; this PR body
- ✅ **TEST** — Vercel build green; Toby user-validated both fixes on TEST iteratively
- ✅ **ROLLBACK** — atomic single-revert documented above
- ✅ **MERGEABILITY** — pre-flight `git merge-tree`: 0 conflicts; TEST fast-forward over PROD (verified 06:13Z)

## 6-gate CRK ratification (Quinn beat-44 protocol)
- ✅ TEST sweep — Vercel build + Toby user-test (iterative)
- ✅ CRK 6-dim — above
- ✅ Regression test — Toby user-verified on TEST
- ⚪ Tier-1/Tier-2 surface evidence — N/A at Tier-3 (admin operational, not user-paramount)
- ✅ Semantic + product-intent — Toby direct product approval on each iteration; visual-only change; no calendar substrate semantic touch
- ⚪ Calendar Invariants applicability — N/A at Tier-3 admin

## Visual smoke checklist (Toby at HITM-merge)
After Vercel PROD auto-deploys (~60-90s):
1. Open https://www.cal-ops.org/dashboard/analytics/activity-map
2. Verify green GPS dots visible on top of red center dots (no more red-overlap-hides-green issue)
3. Verify IPInfoIO records render as dark-gray translucent 50km circles (not small solid dots)
4. Toggle off "Browser GPS" filter button → green dots disappear, red center + line stay visible
5. Toggle back on → green dots return

🤖 Generated with [Claude Code](https://claude.com/claude-code)