### PR TITLE
CALOPS-59: CF Geo Analytics v1.12.0 — userLocation layer, distribution table, time-range filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",

--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -16,7 +16,7 @@ const SOURCE_COLORS = {
 };
 const DEFAULT_USER_COLOR = '#1976d2';
 const CENTER_COLOR = '#d32f2f'; // red
-const LINE_COLOR   = '#757575'; // gray
+const LINE_COLOR   = '#757575'; // gray — used for IPInfoIO lines and unknown sources
 
 // CALOPS-58 Mod 2: default accuracy ring radius (meters) for non-GPS sources.
 // GPS uses real browserGps.accuracy.
@@ -94,6 +94,7 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
 
       <InvalidateOnMount />
       <BoundsReporter onBoundsChange={onBoundsChange} />
+      <MapLegend />
 
       {records.map((rec) => {
         const userLat = rec.userLocation?.latitude;
@@ -186,10 +187,12 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
               </CircleMarker>
             )}
 
-            {/* Connecting line user → mapCenter — ALWAYS rendered (relationship is source-independent) */}
+            {/* Connecting line user → mapCenter — ALWAYS rendered.
+                IPInfoIO stays grey (wide uncertainty; colored line implies false precision).
+                GPS and Google IP get their source color. */}
             <Polyline
               positions={[[userLat, userLng], [mapLat, mapLng]]}
-              pathOptions={{ color: LINE_COLOR, weight: 1, opacity: 0.4, dashArray: '4 4' }}
+              pathOptions={{ color: source === 'IPInfoIO' ? LINE_COLOR : (SOURCE_COLORS[source] || LINE_COLOR), weight: 1, opacity: 0.4, dashArray: '4 4' }}
             >
               <Tooltip sticky direction="center" opacity={0.9}>
                 <span style={{ fontSize: 11 }}>{distLabel}</span>
@@ -202,6 +205,58 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
       <RecenterIfEmpty hasRecords={records.length > 0} />
     </MapContainer>
   );
+}
+
+function MapLegend() {
+  const map = useMap();
+  useEffect(() => {
+    let control;
+    (async () => {
+      const L = (await import('leaflet')).default;
+      const dot  = (color, opacity = 0.9) =>
+        `<span style="display:inline-block;width:11px;height:11px;border-radius:50%;background:${color};opacity:${opacity};margin-right:7px;vertical-align:middle;flex-shrink:0"></span>`;
+      const ring = (color) =>
+        `<span style="display:inline-block;width:13px;height:13px;border-radius:50%;border:2px solid ${color};background:${color};opacity:0.22;margin-right:7px;vertical-align:middle;flex-shrink:0"></span>`;
+      const dash = (color) =>
+        `<span style="display:inline-block;width:18px;height:0;border-top:2px dashed ${color};opacity:0.6;margin-right:7px;vertical-align:middle;flex-shrink:0"></span>`;
+
+      const row = (icon, label) =>
+        `<div style="display:flex;align-items:center;margin-bottom:4px">${icon}<span>${label}</span></div>`;
+
+      const Ctrl = L.Control.extend({
+        onAdd() {
+          const div = L.DomUtil.create('div');
+          div.style.cssText = [
+            'background:rgba(255,255,255,0.93)',
+            'padding:8px 10px',
+            'border-radius:6px',
+            'box-shadow:0 1px 5px rgba(0,0,0,0.28)',
+            'font:12px/1.4 Arial,sans-serif',
+            'color:#333',
+            'min-width:175px',
+            'pointer-events:none',
+          ].join(';');
+          div.innerHTML = [
+            '<strong style="display:block;margin-bottom:6px;font-size:12px">Location source</strong>',
+            row(dot('#2e7d32'), 'Browser GPS (precise)'),
+            row(ring('#1976d2'), 'Google IP (~5 km)'),
+            row(ring('#424242'), 'IP lookup (~50 km)'),
+            '<hr style="margin:5px 0;border:none;border-top:1px solid #ddd">',
+            row(dot('#d32f2f', 0.85), 'Map center viewed'),
+            row(dash('#2e7d32'), 'GPS / Google IP line'),
+            row(dash('#757575'), 'IP lookup line'),
+          ].join('');
+          L.DomEvent.disableClickPropagation(div);
+          L.DomEvent.disableScrollPropagation(div);
+          return div;
+        },
+      });
+      control = new Ctrl({ position: 'bottomleft' });
+      control.addTo(map);
+    })();
+    return () => { if (control) control.remove(); };
+  }, [map]);
+  return null;
 }
 
 function RecenterIfEmpty({ hasRecords }) {

--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -65,11 +65,19 @@ function FixLeafletIcons() {
 // rendering (dot/ring/popup) but the map-center dot + connecting line for that record stay
 // visible. "Where people looked" (red center) is independent of "how their location was
 // resolved" (source).
-export default function ActivityMapView({ records, onBoundsChange, geoSources }) {
+// CALOPS-59: mapMode controls which layer(s) render:
+//   'both'           — user dots + map center dots + connecting line (default)
+//   'mapCenter'      — only red map-center dots (where they browsed)
+//   'userLocation'   — only colored user dots/rings (where they physically are)
+export default function ActivityMapView({ records, onBoundsChange, geoSources, mapMode = 'both' }) {
   const sourceSet = geoSources instanceof Set
     ? geoSources
     : Array.isArray(geoSources) ? new Set(geoSources) : null;
   const sourceVisible = (src) => sourceSet == null ? true : sourceSet.has(src);
+
+  const showUserSide  = mapMode !== 'mapCenter';
+  const showMapCenter = mapMode !== 'userLocation';
+  const showLine      = mapMode === 'both';
   const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
   const tileUrl = mapboxToken
     ? `https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token=${mapboxToken}`
@@ -94,14 +102,18 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
 
       <InvalidateOnMount />
       <BoundsReporter onBoundsChange={onBoundsChange} />
-      <MapLegend />
+      <MapLegend mapMode={mapMode} />
 
       {records.map((rec) => {
         const userLat = rec.userLocation?.latitude;
         const userLng = rec.userLocation?.longitude;
         const mapLat  = rec.mapCenter?.latitude;
         const mapLng  = rec.mapCenter?.longitude;
-        if (userLat == null || userLng == null || mapLat == null || mapLng == null) return null;
+
+        // Each mode only requires the coords it will actually render
+        const needsUser   = showUserSide  && (userLat == null || userLng == null);
+        const needsCenter = showMapCenter && (mapLat  == null || mapLng  == null);
+        if (needsUser || needsCenter) return null;
 
         const source   = rec.userLocation?.source;
         const userColor = SOURCE_COLORS[source] || DEFAULT_USER_COLOR;
@@ -115,7 +127,7 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
             ? `~${Math.round(DEFAULT_ACCURACY_M[source] / 1000)} km (default)`
             : 'unknown';
         const userId = rec.firebaseUserId?.slice(-8) || (rec.ip ? `ip:${rec.ip}` : 'anon');
-        const distKm = haversineKm(userLat, userLng, mapLat, mapLng);
+        const distKm = (mapLat != null && mapLng != null) ? haversineKm(userLat, userLng, mapLat, mapLng) : null;
         const distLabel = formatKm(distKm);
 
         // CALOPS-58e: precise sources (GPS) render dot+ring; imprecise sources (Google IP,
@@ -130,19 +142,19 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
               <strong>User:</strong> {userId}<br />
               <strong>Source:</strong> {source || 'unknown'}<br />
               <strong>Accuracy:</strong> {accuracyLabel}<br />
-              <strong>Distance to viewed center:</strong> {distLabel}<br />
+              {distLabel !== '—' && <><strong>Distance to viewed center:</strong> {distLabel}<br /></>}
               <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
             </div>
           </Popup>
         );
 
-        const showUserSide = sourceVisible(source);
+        const showUserDot = showUserSide && sourceVisible(source);
 
         return (
           <Fragment key={rec.id}>
-            {/* User-side rendering (ring + dot) — only when source filter shows this source.
-                Red center + line are ALWAYS rendered regardless of source filter. */}
-            {showUserSide && ringRadius != null && (
+            {/* User-side rendering (ring + dot) — only in 'both' or 'userLocation' mode,
+                and only when source filter includes this source. */}
+            {showUserDot && ringRadius != null && (
               <Circle
                 center={[userLat, userLng]}
                 radius={ringRadius}
@@ -158,26 +170,28 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
               </Circle>
             )}
 
-            {/* Map center dot (red) — ALWAYS rendered; drawn BEFORE GPS dot so when user-GPS
-                coincides with map-center, the green user dot stays visible on top. */}
-            <CircleMarker
-              center={[mapLat, mapLng]}
-              radius={5}
-              pathOptions={{ color: CENTER_COLOR, fillColor: CENTER_COLOR, fillOpacity: 0.85, weight: 1 }}
-            >
-              <Popup>
-                <div style={{ fontSize: 12 }}>
-                  <strong>Map center viewed by</strong> {userId}<br />
-                  <strong>At:</strong> {mapLat.toFixed(4)}, {mapLng.toFixed(4)}<br />
-                  <strong>Distance from user:</strong> {distLabel}<br />
-                  <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
-                </div>
-              </Popup>
-            </CircleMarker>
+            {/* Map center dot (red) — only in 'both' or 'mapCenter' mode.
+                Drawn BEFORE GPS dot so the green user dot stays on top when they overlap. */}
+            {showMapCenter && mapLat != null && (
+              <CircleMarker
+                center={[mapLat, mapLng]}
+                radius={5}
+                pathOptions={{ color: CENTER_COLOR, fillColor: CENTER_COLOR, fillOpacity: 0.85, weight: 1 }}
+              >
+                <Popup>
+                  <div style={{ fontSize: 12 }}>
+                    <strong>Map center viewed by</strong> {userId}<br />
+                    <strong>At:</strong> {mapLat.toFixed(4)}, {mapLng.toFixed(4)}<br />
+                    {distLabel !== '—' && <><strong>Distance from user:</strong> {distLabel}<br /></>}
+                    <strong>Time:</strong> {new Date(rec.timestamp).toLocaleString()}
+                  </div>
+                </Popup>
+              </CircleMarker>
+            )}
 
             {/* Solid user dot — only for precise GPS sources; drawn AFTER red center so it
-                stays on top of overlapping red. White stroke for visibility against red. */}
-            {showUserSide && isPrecise && (
+                stays on top. White stroke for visibility against red. */}
+            {showUserDot && isPrecise && (
               <CircleMarker
                 center={[userLat, userLng]}
                 radius={6}
@@ -187,17 +201,18 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
               </CircleMarker>
             )}
 
-            {/* Connecting line user → mapCenter — ALWAYS rendered.
-                IPInfoIO stays grey (wide uncertainty; colored line implies false precision).
-                GPS and Google IP get their source color. */}
-            <Polyline
-              positions={[[userLat, userLng], [mapLat, mapLng]]}
-              pathOptions={{ color: source === 'IPInfoIO' ? LINE_COLOR : (SOURCE_COLORS[source] || LINE_COLOR), weight: 1, opacity: 0.4, dashArray: '4 4' }}
-            >
-              <Tooltip sticky direction="center" opacity={0.9}>
-                <span style={{ fontSize: 11 }}>{distLabel}</span>
-              </Tooltip>
-            </Polyline>
+            {/* Connecting line user → mapCenter — only in 'both' mode.
+                IPInfoIO stays grey; GPS and Google IP get their source color. */}
+            {showLine && userLat != null && mapLat != null && (
+              <Polyline
+                positions={[[userLat, userLng], [mapLat, mapLng]]}
+                pathOptions={{ color: source === 'IPInfoIO' ? LINE_COLOR : (SOURCE_COLORS[source] || LINE_COLOR), weight: 1, opacity: 0.4, dashArray: '4 4' }}
+              >
+                <Tooltip sticky direction="center" opacity={0.9}>
+                  <span style={{ fontSize: 11 }}>{distLabel}</span>
+                </Tooltip>
+              </Polyline>
+            )}
           </Fragment>
         );
       })}
@@ -207,7 +222,7 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources })
   );
 }
 
-function MapLegend() {
+function MapLegend({ mapMode = 'both' }) {
   const map = useMap();
   useEffect(() => {
     let control;
@@ -223,6 +238,32 @@ function MapLegend() {
       const row = (icon, label) =>
         `<div style="display:flex;align-items:center;margin-bottom:4px">${icon}<span>${label}</span></div>`;
 
+      const userRows = [
+        row(dot('#2e7d32'), 'Browser GPS (precise)'),
+        row(ring('#1976d2'), 'Google IP (~5 km)'),
+        row(ring('#424242'), 'IP lookup (~50 km)'),
+      ];
+      const centerRow = row(dot('#d32f2f', 0.85), 'Map center viewed');
+      const lineRows = [
+        row(dash('#2e7d32'), 'GPS / Google IP line'),
+        row(dash('#757575'), 'IP lookup line'),
+      ];
+
+      let rows;
+      if (mapMode === 'userLocation') {
+        rows = ['<strong style="display:block;margin-bottom:6px;font-size:12px">User location</strong>', ...userRows];
+      } else if (mapMode === 'mapCenter') {
+        rows = ['<strong style="display:block;margin-bottom:6px;font-size:12px">Map center viewed</strong>', centerRow];
+      } else {
+        rows = [
+          '<strong style="display:block;margin-bottom:6px;font-size:12px">Location source</strong>',
+          ...userRows,
+          '<hr style="margin:5px 0;border:none;border-top:1px solid #ddd">',
+          centerRow,
+          ...lineRows,
+        ];
+      }
+
       const Ctrl = L.Control.extend({
         onAdd() {
           const div = L.DomUtil.create('div');
@@ -236,16 +277,7 @@ function MapLegend() {
             'min-width:175px',
             'pointer-events:none',
           ].join(';');
-          div.innerHTML = [
-            '<strong style="display:block;margin-bottom:6px;font-size:12px">Location source</strong>',
-            row(dot('#2e7d32'), 'Browser GPS (precise)'),
-            row(ring('#1976d2'), 'Google IP (~5 km)'),
-            row(ring('#424242'), 'IP lookup (~50 km)'),
-            '<hr style="margin:5px 0;border:none;border-top:1px solid #ddd">',
-            row(dot('#d32f2f', 0.85), 'Map center viewed'),
-            row(dash('#2e7d32'), 'GPS / Google IP line'),
-            row(dash('#757575'), 'IP lookup line'),
-          ].join('');
+          div.innerHTML = rows.join('');
           L.DomEvent.disableClickPropagation(div);
           L.DomEvent.disableScrollPropagation(div);
           return div;
@@ -255,7 +287,7 @@ function MapLegend() {
       control.addTo(map);
     })();
     return () => { if (control) control.remove(); };
-  }, [map]);
+  }, [map, mapMode]);
   return null;
 }
 

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -33,6 +33,9 @@ import LocationOnIcon from '@mui/icons-material/LocationOn';
 import WifiIcon from '@mui/icons-material/Wifi';
 import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
 import HomeIcon from '@mui/icons-material/Home';
+import PersonPinCircleIcon from '@mui/icons-material/PersonPinCircle';
+import MapIcon from '@mui/icons-material/Map';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import axios from 'axios';
 import { format, subDays, isValid } from 'date-fns';
 import { useAppContext } from '@/lib/AppContext';
@@ -83,6 +86,9 @@ export default function ActivityMapPage() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  // CALOPS-59: map mode toggle — 'both' | 'mapCenter' | 'userLocation'
+  const [mapMode, setMapMode] = useState('both');
 
   // Client-side filter state (no re-fetch on change)
   const [geoSources, setGeoSources] = useState(ALL_SOURCE_KEYS);
@@ -176,7 +182,10 @@ export default function ActivityMapPage() {
       const userLng = r.userLocation?.longitude;
       const mapLat = r.mapCenter?.latitude;
       const mapLng = r.mapCenter?.longitude;
-      if (userLat == null || userLng == null || mapLat == null || mapLng == null) return false;
+
+      // Only require coords for layers that will actually render
+      if (mapMode !== 'mapCenter'  && (userLat == null || userLng == null)) return false;
+      if (mapMode !== 'userLocation' && (mapLat == null || mapLng == null)) return false;
 
       // CALOPS-58f: source filter is a SOFT filter (applied in ActivityMapView for the
       // user-side rendering only). Red center + line stay visible regardless of source toggle.
@@ -200,16 +209,16 @@ export default function ActivityMapPage() {
 
       return true;
     });
-  }, [records, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
+  }, [records, mapMode, ipFilter, minQty, viewportFilter, viewportBounds, localsOnly, localsKm, ipCounts]);
 
   const mapboxConfigured = !!process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
   const handleSourceToggle = (_e, next) => {
-    // ToggleButtonGroup returns null when all unselected — keep at least one selected? Allow empty (hides all dots).
     setGeoSources(next || []);
   };
 
   const resetFilters = () => {
+    setMapMode('both');
     setGeoSources(ALL_SOURCE_KEYS);
     setMinQty(1);
     setIpFilter('');
@@ -263,6 +272,30 @@ export default function ActivityMapPage() {
               </Button>
 
               <Box sx={{ flexGrow: 1 }} />
+
+              {/* CALOPS-59: mapMode toggle — what to show on the map */}
+              <Box>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  View
+                </Typography>
+                <ToggleButtonGroup
+                  size="small"
+                  value={mapMode}
+                  exclusive
+                  onChange={(_e, v) => v && setMapMode(v)}
+                  aria-label="Map view mode"
+                >
+                  <ToggleButton value="both" sx={{ textTransform: 'none', px: 1 }}>
+                    <CompareArrowsIcon sx={{ fontSize: 14, mr: 0.5 }} />Both
+                  </ToggleButton>
+                  <ToggleButton value="mapCenter" sx={{ textTransform: 'none', px: 1 }}>
+                    <MapIcon sx={{ fontSize: 14, mr: 0.5, color: '#d32f2f' }} />Map Center
+                  </ToggleButton>
+                  <ToggleButton value="userLocation" sx={{ textTransform: 'none', px: 1 }}>
+                    <PersonPinCircleIcon sx={{ fontSize: 14, mr: 0.5, color: '#2e7d32' }} />User Location
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
 
               <Button size="small" onClick={resetFilters} variant="outlined">
                 Reset filters
@@ -409,6 +442,7 @@ export default function ActivityMapPage() {
               records={filteredRecords}
               onBoundsChange={setViewportBounds}
               geoSources={geoSources}
+              mapMode={mapMode}
             />
           </Box>
         </Box>

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -106,8 +106,12 @@ export default function ActivityMapPage() {
       let beReportedTotal = 0;
       for (let page = 0; page < MAX_PAGES; page++) {
         const params = new URLSearchParams();
+        // startDate: start-of-day (midnight from DatePicker is correct)
+        // endDate: force end-of-day so a single-day range (start === finish) includes all records that day
+        const endOfDay = new Date(endDate);
+        endOfDay.setHours(23, 59, 59, 999);
         params.set('startDate', startDate.toISOString());
-        params.set('endDate', endDate.toISOString());
+        params.set('endDate', endOfDay.toISOString());
         params.set('limit', String(PAGE_SIZE));
         params.set('page', String(page));
         params.set('appId', String(appId));

--- a/src/app/dashboard/analytics/activity-tracking/page.js
+++ b/src/app/dashboard/analytics/activity-tracking/page.js
@@ -236,7 +236,7 @@ export default function ActivityTrackingPage() {
     setUserLocationLoading(true);
     try {
       const response = await axios.get(
-        `/api/analytics/user-location-distribution?appId=${appId}&_t=${Date.now()}`
+        `/api/analytics/user-location-distribution?appId=${appId}&range=${timeRange}&_t=${Date.now()}`
       );
       if (response.data?.success) {
         setUserLocationDist(response.data.data || []);
@@ -248,7 +248,7 @@ export default function ActivityTrackingPage() {
     } finally {
       setUserLocationLoading(false);
     }
-  }, [appId]);
+  }, [appId, timeRange]);
 
   // Fetch data based on selected tab
   useEffect(() => {
@@ -786,7 +786,7 @@ export default function ActivityTrackingPage() {
             <Box>
               <Typography variant="h6">Where are our users?</Typography>
               <Typography variant="caption" color="text.secondary">
-                Based on <code>lastKnownLocation</code> on user profiles. Populated by CF geo headers.
+                Users whose <code>lastKnownLocation</code> was updated within the selected time range. Populated by CF geo headers.
                 May show 0 rows until TEST traffic flows.
               </Typography>
             </Box>

--- a/src/app/dashboard/analytics/activity-tracking/page.js
+++ b/src/app/dashboard/analytics/activity-tracking/page.js
@@ -40,6 +40,9 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import LoginIcon from '@mui/icons-material/Login';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import MapIcon from '@mui/icons-material/Map';
+import PeopleIcon from '@mui/icons-material/People';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import axios from 'axios';
 import { useAppContext } from '@/lib/AppContext';
 import { format } from 'date-fns';
@@ -84,8 +87,8 @@ export default function ActivityTrackingPage() {
 
   const [tabValue, setTabValue] = useState(0);
 
-  // Mobile swipe gesture for tab navigation
-  const tabCount = 3;
+  // Mobile swipe gesture for tab navigation — CALOPS-59 adds tab 3 (User Locations)
+  const tabCount = 4;
   const { ref: swipeRef, handlers: swipeHandlers } = useMobileGestures({
     onSwipeLeft: () => setTabValue(prev => Math.min(prev + 1, tabCount - 1)),
     onSwipeRight: () => setTabValue(prev => Math.max(prev - 1, 0)),
@@ -100,6 +103,10 @@ export default function ActivityTrackingPage() {
   const [loginHistory, setLoginHistory] = useState([]);
   const [visitorHistory, setVisitorHistory] = useState([]);
   const [mapCenterHistory, setMapCenterHistory] = useState([]);
+  // CALOPS-59: user location distribution from CALBEAF-191
+  const [userLocationDist, setUserLocationDist] = useState([]);
+  const [userLocationLoading, setUserLocationLoading] = useState(false);
+  const [userLocationSort, setUserLocationSort] = useState({ field: 'count', dir: 'desc' });
 
   // Pagination states
   const [loginPagination, setLoginPagination] = useState({ page: 0, total: 0, pages: 0 });
@@ -224,17 +231,38 @@ export default function ActivityTrackingPage() {
     }
   }, [timeRange, rowsPerPage, buildFilterParams]);
 
+  // CALOPS-59: fetch user location distribution (CALBEAF-191)
+  const fetchUserLocationDist = useCallback(async () => {
+    setUserLocationLoading(true);
+    try {
+      const response = await axios.get(
+        `/api/analytics/user-location-distribution?appId=${appId}&_t=${Date.now()}`
+      );
+      if (response.data?.success) {
+        setUserLocationDist(response.data.data || []);
+      } else {
+        setUserLocationDist([]);
+      }
+    } catch {
+      setUserLocationDist([]);
+    } finally {
+      setUserLocationLoading(false);
+    }
+  }, [appId]);
+
   // Fetch data based on selected tab
   useEffect(() => {
     if (tabValue === 0) fetchLoginHistory(0);
     else if (tabValue === 1) fetchVisitorHistory(0);
     else if (tabValue === 2) fetchMapCenterHistory(0);
-  }, [tabValue, timeRange, fetchLoginHistory, fetchVisitorHistory, fetchMapCenterHistory]);
+    else if (tabValue === 3) fetchUserLocationDist();
+  }, [tabValue, timeRange, fetchLoginHistory, fetchVisitorHistory, fetchMapCenterHistory, fetchUserLocationDist]);
 
   const handleRefresh = () => {
     if (tabValue === 0) fetchLoginHistory(loginPagination.page);
     else if (tabValue === 1) fetchVisitorHistory(visitorPagination.page);
     else if (tabValue === 2) fetchMapCenterHistory(mapCenterPagination.page);
+    else if (tabValue === 3) fetchUserLocationDist();
   };
 
   const handleTimeRangeChange = (event, newValue) => {
@@ -393,7 +421,7 @@ export default function ActivityTrackingPage() {
 
       {/* Info cards */}
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={12} sm={4}>
+        <Grid item xs={12} sm={3}>
           <Paper sx={{ p: 2, borderTop: '4px solid #1976d2' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <LoginIcon color="primary" />
@@ -409,7 +437,7 @@ export default function ActivityTrackingPage() {
             </Typography>
           </Paper>
         </Grid>
-        <Grid item xs={12} sm={4}>
+        <Grid item xs={12} sm={3}>
           <Paper sx={{ p: 2, borderTop: '4px solid #2e7d32' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <VisibilityIcon color="success" />
@@ -425,7 +453,7 @@ export default function ActivityTrackingPage() {
             </Typography>
           </Paper>
         </Grid>
-        <Grid item xs={12} sm={4}>
+        <Grid item xs={12} sm={3}>
           <Paper sx={{ p: 2, borderTop: '4px solid #ed6c02' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <MapIcon color="warning" />
@@ -441,6 +469,22 @@ export default function ActivityTrackingPage() {
             </Typography>
           </Paper>
         </Grid>
+        <Grid item xs={12} sm={3}>
+          <Paper sx={{ p: 2, borderTop: '4px solid #7b1fa2' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <PeopleIcon sx={{ color: '#7b1fa2' }} />
+              <Box>
+                <Typography variant="h6">User Locations</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  lastKnownLocation per user
+                </Typography>
+              </Box>
+            </Box>
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              Where are our users? City/country distribution
+            </Typography>
+          </Paper>
+        </Grid>
       </Grid>
 
       {/* Tabs */}
@@ -449,6 +493,7 @@ export default function ActivityTrackingPage() {
           <Tab icon={<LoginIcon />} label="Login History" iconPosition="start" />
           <Tab icon={<VisibilityIcon />} label="Visitor Tracking" iconPosition="start" />
           <Tab icon={<MapIcon />} label="Map Center" iconPosition="start" />
+          <Tab icon={<PeopleIcon />} label="User Locations" iconPosition="start" />
         </Tabs>
       </Paper>
 
@@ -631,7 +676,7 @@ export default function ActivityTrackingPage() {
         </Paper>
       )}
 
-      {/* Map Center Tab */}
+      {/* Map Center Tab — CALOPS-59: added userLocation.city/country, cascadeSource, frequency */}
       {!loading && tabValue === 2 && (
         <Paper sx={{ p: 2 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
@@ -652,40 +697,73 @@ export default function ActivityTrackingPage() {
                     <TableCell>User ID</TableCell>
                     <TableCell>IP</TableCell>
                     <TableCell>Map Center</TableCell>
-                    <TableCell>Device</TableCell>
                     <TableCell>User Location</TableCell>
+                    <TableCell>Cascade Source</TableCell>
+                    <TableCell>
+                      <Tooltip title="How many times this user changed their map center this session" arrow>
+                        <span>Freq</span>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>Source</TableCell>
+                    <TableCell>Device</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {mapCenterHistory.map((entry, i) => (
-                    <TableRow key={entry.id || i} hover>
-                      <TableCell sx={{ fontSize: '0.75rem', whiteSpace: 'nowrap' }}>
-                        {entry.timestamp ? format(new Date(entry.timestamp), 'MMM d, h:mm a') : '-'}
-                      </TableCell>
-                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
-                        <Tooltip title={entry.firebaseUserId || 'No user ID'} arrow>
-                          <span style={{ cursor: 'pointer' }}>{entry.firebaseUserId?.slice(-8) || '-'}</span>
-                        </Tooltip>
-                      </TableCell>
-                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
-                        {entry.ip || '-'}
-                      </TableCell>
-                      <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
-                        {entry.mapCenter?.latitude?.toFixed(4) || '-'}, {entry.mapCenter?.longitude?.toFixed(4) || '-'}
-                      </TableCell>
-                      <TableCell>
-                        <Chip
-                          label={entry.deviceType || 'unknown'}
-                          size="small"
-                          color={entry.deviceType === 'mobile' ? 'primary' : entry.deviceType === 'tablet' ? 'secondary' : 'default'}
-                          sx={{ fontSize: '0.7rem' }}
-                        />
-                      </TableCell>
-                      <TableCell sx={{ fontSize: '0.75rem' }}>
-                        {[entry.userLocation?.ipLookup?.city, entry.userLocation?.ipLookup?.region, entry.userLocation?.ipLookup?.country].filter(Boolean).join(', ') || '-'}
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {mapCenterHistory.map((entry, i) => {
+                    const ulCity    = entry.userLocation?.city;
+                    const ulCountry = entry.userLocation?.country;
+                    const ulDisplay = [ulCity, ulCountry].filter(Boolean).join(', ') || '-';
+                    return (
+                      <TableRow key={entry.id || i} hover>
+                        <TableCell sx={{ fontSize: '0.75rem', whiteSpace: 'nowrap' }}>
+                          {entry.timestamp ? format(new Date(entry.timestamp), 'MMM d, h:mm a') : '-'}
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                          <Tooltip title={entry.firebaseUserId || 'No user ID'} arrow>
+                            <span style={{ cursor: 'pointer' }}>{entry.firebaseUserId?.slice(-8) || '-'}</span>
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                          {entry.ip || '-'}
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                          <Tooltip title={`${entry.mapCenter?.latitude?.toFixed(5) || '-'}, ${entry.mapCenter?.longitude?.toFixed(5) || '-'}`} arrow>
+                            <span>
+                              {[entry.mapCenter?.city, entry.mapCenter?.country].filter(Boolean).join(', ')
+                                || `${entry.mapCenter?.latitude?.toFixed(3) || '-'}, ${entry.mapCenter?.longitude?.toFixed(3) || '-'}`}
+                            </span>
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell sx={{ fontSize: '0.75rem' }}>
+                          {ulDisplay}
+                        </TableCell>
+                        <TableCell>
+                          {entry.cascadeSource ? (
+                            <Chip
+                              label={entry.cascadeSource}
+                              size="small"
+                              variant="outlined"
+                              sx={{ fontSize: '0.65rem', height: 20 }}
+                            />
+                          ) : '-'}
+                        </TableCell>
+                        <TableCell sx={{ fontSize: '0.75rem', textAlign: 'center' }}>
+                          {entry.frequency ?? '-'}
+                        </TableCell>
+                        <TableCell>
+                          {getSourceChip(entry.userLocation)}
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={entry.deviceType || 'unknown'}
+                            size="small"
+                            color={entry.deviceType === 'mobile' ? 'primary' : entry.deviceType === 'tablet' ? 'secondary' : 'default'}
+                            sx={{ fontSize: '0.7rem' }}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
               <TablePagination
@@ -698,6 +776,99 @@ export default function ActivityTrackingPage() {
                 rowsPerPageOptions={[25, 50, 100]}
               />
             </>
+          )}
+        </Paper>
+      )}
+      {/* User Locations Tab — CALOPS-59: where are our users? (lastKnownLocation distribution) */}
+      {tabValue === 3 && (
+        <Paper sx={{ p: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+            <Box>
+              <Typography variant="h6">Where are our users?</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Based on <code>lastKnownLocation</code> on user profiles. Populated by CF geo headers.
+                May show 0 rows until TEST traffic flows.
+              </Typography>
+            </Box>
+          </Box>
+
+          {userLocationLoading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+            </Box>
+          ) : userLocationDist.length === 0 ? (
+            <Typography color="text.secondary" textAlign="center" py={4}>
+              No user location data yet — will populate as logged-in users visit on TEST.
+            </Typography>
+          ) : (
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>#</TableCell>
+                  <TableCell>
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5, cursor: 'pointer', userSelect: 'none' }}
+                      onClick={() => setUserLocationSort(s =>
+                        s.field === 'city' ? { field: 'city', dir: s.dir === 'asc' ? 'desc' : 'asc' } : { field: 'city', dir: 'asc' }
+                      )}
+                    >
+                      City
+                      {userLocationSort.field === 'city' && (
+                        userLocationSort.dir === 'asc' ? <ArrowUpwardIcon sx={{ fontSize: 14 }} /> : <ArrowDownwardIcon sx={{ fontSize: 14 }} />
+                      )}
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5, cursor: 'pointer', userSelect: 'none' }}
+                      onClick={() => setUserLocationSort(s =>
+                        s.field === 'country' ? { field: 'country', dir: s.dir === 'asc' ? 'desc' : 'asc' } : { field: 'country', dir: 'asc' }
+                      )}
+                    >
+                      Country
+                      {userLocationSort.field === 'country' && (
+                        userLocationSort.dir === 'asc' ? <ArrowUpwardIcon sx={{ fontSize: 14 }} /> : <ArrowDownwardIcon sx={{ fontSize: 14 }} />
+                      )}
+                    </Box>
+                  </TableCell>
+                  <TableCell align="right">
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.5, cursor: 'pointer', userSelect: 'none' }}
+                      onClick={() => setUserLocationSort(s =>
+                        s.field === 'count' ? { field: 'count', dir: s.dir === 'asc' ? 'desc' : 'asc' } : { field: 'count', dir: 'desc' }
+                      )}
+                    >
+                      Users
+                      {userLocationSort.field === 'count' && (
+                        userLocationSort.dir === 'asc' ? <ArrowUpwardIcon sx={{ fontSize: 14 }} /> : <ArrowDownwardIcon sx={{ fontSize: 14 }} />
+                      )}
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {[...userLocationDist]
+                  .sort((a, b) => {
+                    const { field, dir } = userLocationSort;
+                    const av = (a[field] ?? '').toString().toLowerCase();
+                    const bv = (b[field] ?? '').toString().toLowerCase();
+                    const cmp = field === 'count'
+                      ? (Number(a.count) || 0) - (Number(b.count) || 0)
+                      : av.localeCompare(bv);
+                    return dir === 'asc' ? cmp : -cmp;
+                  })
+                  .map((row, i) => (
+                    <TableRow key={`${row.city}-${row.country}-${i}`} hover>
+                      <TableCell sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>{i + 1}</TableCell>
+                      <TableCell sx={{ fontSize: '0.85rem' }}>{row.city || '—'}</TableCell>
+                      <TableCell>
+                        <Chip label={row.country || '?'} size="small" variant="outlined" sx={{ fontSize: '0.7rem', height: 22 }} />
+                      </TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 600, fontSize: '0.85rem' }}>{row.count}</TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
           )}
         </Paper>
       )}


### PR DESCRIPTION
## Summary

- **userLocation layer** on Activity Map — shows where users physically are (GPS/Google/IP colored dots)
- **User location distribution table** — city/country breakdown of `lastKnownLocation`, cohort-filtered by the time-range toggle (`range=` param wired to Fulton's CALBEAF-191 endpoint)
- **mapCenter tab enhancements** — cascade/frequency columns, legend, IPInfoIO line color, endDate fix
- **v1.12.0** version bump

## Scope (Quinn-confirmed, Sprint 6 TEST sign-off)
- Item 1: userLocation + mapCenter analytics display ✅
- Item 2: User location distribution table ✅
- Item 3: Date-range filter on distribution table ✅ (wired `range=${timeRange}` — cohort filter by `lastKnownLocation.updatedAt`)

## Test plan
- [ ] Activity Map: toggle between Both / mapCenter / userLocation modes
- [ ] User location distribution table populates (may be sparse on TEST until traffic flows)
- [ ] Time-range toggle changes distribution results
- [ ] Sortable columns (City, Country, Users) work
- [ ] Activity tracking tabs 0-3 all load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)