### PR TITLE
CALOPS-59: CloudflareEdge source + IPInfoIO ring + mobile map fix

### DIFF
--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -12,6 +12,7 @@ const USA_ZOOM = 4;
 const SOURCE_COLORS = {
   GoogleBrowser:     '#2e7d32', // green — Browser GPS
   GoogleGeolocation: '#1976d2', // blue — Google IP
+  CloudflareEdge:    '#e65100', // orange — Cloudflare edge geo
   IPInfoIO:          '#424242', // dark gray — IP lookup (was #757575)
 };
 const DEFAULT_USER_COLOR = '#1976d2';
@@ -22,6 +23,7 @@ const LINE_COLOR   = '#757575'; // gray — used for IPInfoIO lines and unknown 
 // GPS uses real browserGps.accuracy.
 const DEFAULT_ACCURACY_M = {
   GoogleGeolocation: 5000,   // Google IP geolocation ~5 km typical
+  CloudflareEdge:    15000,  // Cloudflare edge geo ~15 km typical
   IPInfoIO:          50000,  // IP lookup ~50 km typical
 };
 
@@ -130,11 +132,12 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources, m
         const distKm = (mapLat != null && mapLng != null) ? haversineKm(userLat, userLng, mapLat, mapLng) : null;
         const distLabel = formatKm(distKm);
 
-        // CALOPS-58e: precise sources (GPS) render dot+ring; imprecise sources (Google IP,
-        // IP lookup) render only the translucent uncertainty circle — the circle IS the marker.
-        // Avoids false-precision of a small dot at the centroid of a 5-50 km uncertainty cloud.
+        // CALOPS-58e: precise sources (GPS) render dot+ring; imprecise sources render only
+        // the translucent uncertainty circle — the circle IS the marker.
+        // IPInfoIO gets a very faint ring (huge 50km radius looks heavy at normal opacity).
         const isPrecise = source === 'GoogleBrowser';
-        const ringOpacity = isPrecise ? 0.12 : 0.20;
+        const ringOpacity = isPrecise ? 0.12 : source === 'IPInfoIO' ? 0.05 : 0.15;
+        const ringWeight  = source === 'IPInfoIO' ? 0.5 : 1;
 
         const userPopupBody = (
           <Popup>
@@ -162,7 +165,7 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources, m
                   color: userColor,
                   fillColor: userColor,
                   fillOpacity: ringOpacity,
-                  weight: 1,
+                  weight: ringWeight,
                 }}
                 interactive={!isPrecise}
               >
@@ -241,6 +244,7 @@ function MapLegend({ mapMode = 'both' }) {
       const userRows = [
         row(dot('#2e7d32'), 'Browser GPS (precise)'),
         row(ring('#1976d2'), 'Google IP (~5 km)'),
+        row(ring('#e65100'), 'Cloudflare edge (~15 km)'),
         row(ring('#424242'), 'IP lookup (~50 km)'),
       ];
       const centerRow = row(dot('#d32f2f', 0.85), 'Map center viewed');

--- a/src/app/dashboard/analytics/activity-map/page.js
+++ b/src/app/dashboard/analytics/activity-map/page.js
@@ -55,9 +55,10 @@ const TARGET_TOTAL = 1000;
 const MAX_PAGES = TARGET_TOTAL / PAGE_SIZE;
 
 const SOURCE_OPTIONS = [
-  { key: 'GoogleBrowser',     label: 'Browser GPS', color: '#2e7d32' },
-  { key: 'GoogleGeolocation', label: 'Google IP',   color: '#1976d2' },
-  { key: 'IPInfoIO',          label: 'IP lookup',   color: '#757575' },
+  { key: 'GoogleBrowser',     label: 'Browser GPS',   color: '#2e7d32' },
+  { key: 'GoogleGeolocation', label: 'Google IP',     color: '#1976d2' },
+  { key: 'CloudflareEdge',    label: 'Cloudflare',    color: '#e65100' },
+  { key: 'IPInfoIO',          label: 'IP lookup',     color: '#757575' },
 ];
 const ALL_SOURCE_KEYS = SOURCE_OPTIONS.map((s) => s.key);
 
@@ -229,7 +230,7 @@ export default function ActivityMapPage() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 100px)', minHeight: 600 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: { xs: 'auto', md: 'calc(100vh - 100px)' }, minHeight: { xs: 'auto', md: 600 } }}>
         <Box sx={{ p: 2, pb: 1, flexShrink: 0 }}>
           <Typography variant="h5" gutterBottom>
             User Activity — Map &amp; Center
@@ -309,7 +310,7 @@ export default function ActivityMapPage() {
               {/* Geo source multi-select */}
               <Box>
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
-                  Map-center source
+                  Location source
                 </Typography>
                 <ToggleButtonGroup
                   size="small"
@@ -424,7 +425,8 @@ export default function ActivityMapPage() {
           mb: 2,
           border: '1px solid',
           borderColor: 'divider',
-          minHeight: 500,
+          height: { xs: 380, md: 'auto' },
+          minHeight: { xs: 380, md: 500 },
           overflow: 'hidden',
         }}>
           {loading && (


### PR DESCRIPTION
## Summary

- **CloudflareEdge** source added: orange (#e65100), ~15km default ring, filter button, legend entry — source key confirmed by Fulton
- **IPInfoIO accuracy ring**: fillOpacity 0.20 → 0.05, weight 1 → 0.5 (50km circle was visually heavy)
- **Mobile map**: fixed 380px height on xs screens so map renders below the filter bar
- **Label fix**: "Map-center source" → "Location source"

## Test plan
- [ ] Activity Map loads on mobile — map visible without scrolling
- [ ] IPInfoIO rings are noticeably lighter/more transparent
- [ ] CloudflareEdge button appears in Location source filter (orange)
- [ ] CloudflareEdge legend entry shows in bottom-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)