### PR TITLE
CALOPS-59: fix distribution fetch from/to params (CRK gap)

### DIFF
--- a/src/app/dashboard/analytics/activity-tracking/page.js
+++ b/src/app/dashboard/analytics/activity-tracking/page.js
@@ -45,7 +45,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import axios from 'axios';
 import { useAppContext } from '@/lib/AppContext';
-import { format } from 'date-fns';
+import { format, subHours, subDays, subMonths, subYears } from 'date-fns';
 import { useMobileGestures } from '@/hooks/useMobileGestures';
 
 // Helper to get location source display
@@ -74,6 +74,22 @@ const getSourceChip = (location) => {
     </Tooltip>
   );
 };
+
+// Translate timeRange shortcode to {from, to} ISO strings for endpoints
+// that use from=/to= params (e.g. user-location-distribution).
+function timeRangeToFromTo(range) {
+  const to = new Date();
+  const from = {
+    '1H':  subHours(to, 1),
+    '1D':  subDays(to, 1),
+    '7D':  subDays(to, 7),
+    '1M':  subMonths(to, 1),
+    '3M':  subMonths(to, 3),
+    '1Yr': subYears(to, 1),
+  }[range];
+  if (!from) return '';
+  return `&from=${from.toISOString()}&to=${to.toISOString()}`;
+}
 
 /**
  * Activity Tracking Dashboard
@@ -236,7 +252,7 @@ export default function ActivityTrackingPage() {
     setUserLocationLoading(true);
     try {
       const response = await axios.get(
-        `/api/analytics/user-location-distribution?appId=${appId}&range=${timeRange}&_t=${Date.now()}`
+        `/api/analytics/user-location-distribution?appId=${appId}${timeRangeToFromTo(timeRange)}&_t=${Date.now()}`
       );
       if (response.data?.success) {
         setUserLocationDist(response.data.data || []);


### PR DESCRIPTION
## Summary

CRK gap fix: `user-location-distribution` endpoint uses `from=`/`to=` ISO strings, not `range=`. Previous fetch was silently passing `range=7D` which was ignored — always returning all-time data.

Added `timeRangeToFromTo()` helper that translates shortcodes (1H/1D/7D/1M/3M/1Yr/All) to ISO date params. `All` sends no date params (all-time, correct behavior).

## Test plan
- [ ] Changing the time-range toggle on the User Locations tab changes the row count
- [ ] "All" still returns all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)