### PR TITLE
CALOPS-61 fix: fallback dot for Unknown/ModalPick sources → TEST

### DIFF
--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -206,6 +206,17 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources, m
               </CircleMarker>
             )}
 
+            {/* Fallback dot for sources with no ring radius (Unknown, ModalPick, etc.) */}
+            {showUserDot && !isPrecise && ringRadius == null && (
+              <CircleMarker
+                center={[userLat, userLng]}
+                radius={5}
+                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.8, weight: 1 }}
+              >
+                {userPopupBody}
+              </CircleMarker>
+            )}
+
             {/* Connecting line user → mapCenter — only in 'both' mode.
                 IPInfoIO stays grey; GPS and Google IP get their source color. */}
             {showLine && userLat != null && mapLat != null && (


### PR DESCRIPTION
## Fix: ActivityMapView fallback dot for Unknown/ModalPick sources

**Root cause:** Sources not in `DEFAULT_ACCURACY_M` (Unknown, ModalPick) had valid lat/lng
but rendered nothing on the map — no ring (ringRadius=null) and no dot (not isPrecise).

**Fix:** Added fallback `CircleMarker` so all records with coordinates are visible, colored
by their `geoSource` (grey for Unknown, purple for ModalPick, etc.).

**Impact:** Session Geo Distribution map now shows dots for the 2 existing Unknown records
(Boston + Milton). CloudflareEdge record (Austin) was already rendering (just faint at zoom 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)