### PR TITLE
CALOPS-61 fix: ActivityMapView fallback dot (Unknown/ModalPick) → PROD

### DIFF
--- a/src/app/dashboard/analytics/activity-map/ActivityMapView.js
+++ b/src/app/dashboard/analytics/activity-map/ActivityMapView.js
@@ -206,6 +206,17 @@ export default function ActivityMapView({ records, onBoundsChange, geoSources, m
               </CircleMarker>
             )}
 
+            {/* Fallback dot for sources with no ring radius (Unknown, ModalPick, etc.) */}
+            {showUserDot && !isPrecise && ringRadius == null && (
+              <CircleMarker
+                center={[userLat, userLng]}
+                radius={5}
+                pathOptions={{ color: userColor, fillColor: userColor, fillOpacity: 0.8, weight: 1 }}
+              >
+                {userPopupBody}
+              </CircleMarker>
+            )}
+
             {/* Connecting line user → mapCenter — only in 'both' mode.
                 IPInfoIO stays grey; GPS and Google IP get their source color. */}
             {showLine && userLat != null && mapLat != null && (


### PR DESCRIPTION
## Fix: Session Geo map dots not showing for Unknown/ModalPick sources

**Root cause:** Sources not in `DEFAULT_ACCURACY_M` (Unknown, ModalPick) had valid
lat/lng but rendered nothing on the map — ringRadius=null and not isPrecise, so both
rendering paths were skipped silently.

**Fix:** Added fallback `CircleMarker` (radius 5, 80% opacity) for any source with
valid coordinates but no ring radius. Colored by geoSource (grey=Unknown, purple=ModalPick).

**Verified:** 3 of 6 existing PROD records have lat/lng and will now render as dots:
- Boston (Unknown, L1) 
- Milton (Unknown, L3)
- Austin (CloudflareEdge, L3 — was already rendering but faint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)