### PR TITLE
v1.13.1: CALOPS-61 dot-fix → PROD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "master-calendar-operations",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Administration application for Calendar Backend",
   "main": "server.js",
   "type": "module",


### PR DESCRIPTION
## v1.13.1 — ActivityMapView fallback dot fix

Patch bump for PROD promotion. Includes:
- ActivityMapView: fallback CircleMarker for Unknown/ModalPick sources (records with valid lat/lng but no ring radius now render as colored dots)
- Version bump 1.13.0 → 1.13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)